### PR TITLE
Split searching into using its own single index, everything else is partitioned by plan ID

### DIFF
--- a/internal/etoe/etoe_test.go
+++ b/internal/etoe/etoe_test.go
@@ -40,11 +40,11 @@ var (
 	vaultType = flag.String("vault", "sqlite", "The type of storage vault to use.")
 
 	// CosmosDB flags that are only used if vault is set to "cosmosdb".
-	collection = flag.String("collection", os.Getenv("AZURE_COSMOSDB_COLLECTION"), "The name of the cosmosdb collection.")
-	db         = flag.String("db", os.Getenv("AZURE_COSMOSDB_DBNAME"), "The name of the cosmosdb database.")
-	container  = flag.String("container", os.Getenv("AZURE_COSMOSDB_CNAME"), "The name of the cosmosdb container.")
-	msi        = flag.String("msi", "", "The identity with vmss contributor role. If empty, az login is used.")
-	teardown   = flag.Bool("teardown", false, "Teardown the cosmosdb container.")
+	swarm     = flag.String("collection", os.Getenv("AZURE_COSMOSDB_SWARM"), "The name of the coercion swarm.")
+	db        = flag.String("db", os.Getenv("AZURE_COSMOSDB_DBNAME"), "The name of the cosmosdb database.")
+	container = flag.String("container", os.Getenv("AZURE_COSMOSDB_CNAME"), "The name of the cosmosdb container.")
+	msi       = flag.String("msi", "", "The identity with vmss contributor role. If empty, az login is used.")
+	teardown  = flag.Bool("teardown", false, "Teardown the cosmosdb container.")
 )
 
 func TestEtoE(t *testing.T) {
@@ -189,7 +189,7 @@ func TestEtoE(t *testing.T) {
 		vault, err = sqlite.New(ctx, "", reg, sqlite.WithInMemory())
 	case "cosmosdb":
 		logger.Info(fmt.Sprintf("TestEtoE: Using cosmosdb: %s, %s", *db, *container))
-		vault, err = cosmosdb.New(ctx, *collection, *db, *container, cred, reg)
+		vault, err = cosmosdb.New(ctx, *swarm, *db, *container, cred, reg)
 	default:
 		panic(fmt.Errorf("TestEtoE: unknown storage vault type: %s", *vaultType))
 	}
@@ -405,7 +405,7 @@ func TestBypassPlan(t *testing.T) {
 		vault, err = sqlite.New(ctx, "", reg, sqlite.WithInMemory())
 	case "cosmosdb":
 		logger.Info(fmt.Sprintf("TestBypassPlan: Using cosmosdb: %s, %s", *db, *container))
-		vault, err = cosmosdb.New(ctx, *collection, *db, *container, cred, reg)
+		vault, err = cosmosdb.New(ctx, *swarm, *db, *container, cred, reg)
 	default:
 		panic(fmt.Errorf("TestBypassPlan: unknown storage vault type: %s", *vaultType))
 	}
@@ -588,7 +588,7 @@ func TestBypassBlock(t *testing.T) {
 		vault, err = sqlite.New(ctx, "", reg, sqlite.WithInMemory())
 	case "cosmosdb":
 		logger.Info(fmt.Sprintf("TestBypassBlock: Using cosmosdb: %s, %s", *db, *container))
-		vault, err = cosmosdb.New(ctx, *collection, *db, *container, cred, reg)
+		vault, err = cosmosdb.New(ctx, *swarm, *db, *container, cred, reg)
 	default:
 		panic(fmt.Errorf("TestBypassBlock: unknown storage vault type: %s", *vaultType))
 	}

--- a/internal/etoe/etoe_test.go
+++ b/internal/etoe/etoe_test.go
@@ -40,11 +40,11 @@ var (
 	vaultType = flag.String("vault", "sqlite", "The type of storage vault to use.")
 
 	// CosmosDB flags that are only used if vault is set to "cosmosdb".
-	db        = flag.String("db", os.Getenv("AZURE_COSMOSDB_DBNAME"), "The name of the cosmosdb database.")
-	container = flag.String("container", os.Getenv("AZURE_COSMOSDB_CNAME"), "The name of the cosmosdb container.")
-	pk        = flag.String("partition-key", os.Getenv("AZURE_COSMOSDB_PK"), "The name of the cosmosdb partition key.")
-	msi       = flag.String("msi", "", "The identity with vmss contributor role. If empty, az login is used.")
-	teardown  = flag.Bool("teardown", false, "Teardown the cosmosdb container.")
+	collection = flag.String("collection", os.Getenv("AZURE_COSMOSDB_COLLECTION"), "The name of the cosmosdb collection.")
+	db         = flag.String("db", os.Getenv("AZURE_COSMOSDB_DBNAME"), "The name of the cosmosdb database.")
+	container  = flag.String("container", os.Getenv("AZURE_COSMOSDB_CNAME"), "The name of the cosmosdb container.")
+	msi        = flag.String("msi", "", "The identity with vmss contributor role. If empty, az login is used.")
+	teardown   = flag.Bool("teardown", false, "Teardown the cosmosdb container.")
 )
 
 func TestEtoE(t *testing.T) {
@@ -188,8 +188,8 @@ func TestEtoE(t *testing.T) {
 	case "sqlite":
 		vault, err = sqlite.New(ctx, "", reg, sqlite.WithInMemory())
 	case "cosmosdb":
-		logger.Info(fmt.Sprintf("TestEtoE: Using cosmosdb: %s, %s, %s", *db, *container, *pk))
-		vault, err = cosmosdb.New(ctx, *db, *container, cred, reg)
+		logger.Info(fmt.Sprintf("TestEtoE: Using cosmosdb: %s, %s", *db, *container))
+		vault, err = cosmosdb.New(ctx, *collection, *db, *container, cred, reg)
 	default:
 		panic(fmt.Errorf("TestEtoE: unknown storage vault type: %s", *vaultType))
 	}
@@ -404,8 +404,8 @@ func TestBypassPlan(t *testing.T) {
 	case "sqlite":
 		vault, err = sqlite.New(ctx, "", reg, sqlite.WithInMemory())
 	case "cosmosdb":
-		logger.Info(fmt.Sprintf("TestBypassPlan: Using cosmosdb: %s, %s, %s", *db, *container, *pk))
-		vault, err = cosmosdb.New(ctx, *db, *container, cred, reg)
+		logger.Info(fmt.Sprintf("TestBypassPlan: Using cosmosdb: %s, %s", *db, *container))
+		vault, err = cosmosdb.New(ctx, *collection, *db, *container, cred, reg)
 	default:
 		panic(fmt.Errorf("TestBypassPlan: unknown storage vault type: %s", *vaultType))
 	}
@@ -587,8 +587,8 @@ func TestBypassBlock(t *testing.T) {
 	case "sqlite":
 		vault, err = sqlite.New(ctx, "", reg, sqlite.WithInMemory())
 	case "cosmosdb":
-		logger.Info(fmt.Sprintf("TestBypassBlock: Using cosmosdb: %s, %s, %s", *db, *container, *pk))
-		vault, err = cosmosdb.New(ctx, *db, *container, cred, reg)
+		logger.Info(fmt.Sprintf("TestBypassBlock: Using cosmosdb: %s, %s", *db, *container))
+		vault, err = cosmosdb.New(ctx, *collection, *db, *container, cred, reg)
 	default:
 		panic(fmt.Errorf("TestBypassBlock: unknown storage vault type: %s", *vaultType))
 	}
@@ -671,9 +671,6 @@ func validateFlags() error {
 		}
 		if *container == "" {
 			return fmt.Errorf("missing container name")
-		}
-		if *pk == "" {
-			return fmt.Errorf("missing partition key")
 		}
 	}
 	return nil

--- a/internal/etoe/etoe_test.go
+++ b/internal/etoe/etoe_test.go
@@ -40,7 +40,7 @@ var (
 	vaultType = flag.String("vault", "sqlite", "The type of storage vault to use.")
 
 	// CosmosDB flags that are only used if vault is set to "cosmosdb".
-	swarm     = flag.String("collection", os.Getenv("AZURE_COSMOSDB_SWARM"), "The name of the coercion swarm.")
+	swarm     = flag.String("swarm", os.Getenv("AZURE_COSMOSDB_SWARM"), "The name of the coercion swarm.")
 	db        = flag.String("db", os.Getenv("AZURE_COSMOSDB_DBNAME"), "The name of the cosmosdb database.")
 	container = flag.String("container", os.Getenv("AZURE_COSMOSDB_CNAME"), "The name of the cosmosdb container.")
 	msi       = flag.String("msi", "", "The identity with vmss contributor role. If empty, az login is used.")

--- a/workflow/storage/cosmosdb/READ_FIRST.md
+++ b/workflow/storage/cosmosdb/READ_FIRST.md
@@ -4,8 +4,8 @@ We will CHANGE HOW WE STORE THE DATA HERE AT WILL, THIS IS LIKELY TO CATCH YOU O
 
 The main reason is that the CosmosDB Go SDK is incomplete and missing a lot of features like cross partition scanning. This makes doing search very difficult.
 
-You could put everything in a single parition, but that means no horizontal scaling and very limting compute RUs.
+You could put everything in a single partition, but that means no horizontal scaling and very limiting compute RUs.
 
-So we don't do that, but we do use a single search key and store search records. This means searches can only be done on a single partition worth of compute at 10K RU and have a storage limit of 20 GiB. This means you have to perodically clean out storage.
+So we don't do that, but we do use a single search key and store search records. This means searches can only be done on a single partition worth of compute at 10K RU and have a storage limit of 20 GiB. This means you have to periodically clean out storage.
 
-It also can not be written atomically, because you cannot write across partition keys in an atomic manner. This would not matter if you could scan scross partition, but as we can't...
+It also can not be written atomically, because you cannot write across partition keys in an atomic manner. This would not matter if you could scan across partitions, but as we can't...

--- a/workflow/storage/cosmosdb/READ_FIRST.md
+++ b/workflow/storage/cosmosdb/READ_FIRST.md
@@ -1,0 +1,11 @@
+This package allows use of CosmosDB as a data store. This is considered experimental.
+
+We will CHANGE HOW WE STORE THE DATA HERE AT WILL, THIS IS LIKELY TO CATCH YOU OFF GUARD. AKA DON'T USE THIS UNTIL THIS FILE IS REMOVED, USE SQLite storage.
+
+The main reason is that the CosmosDB Go SDK is incomplete and missing a lot of features like cross partition scanning. This makes doing search very difficult.
+
+You could put everything in a single parition, but that means no horizontal scaling and very limting compute RUs.
+
+So we don't do that, but we do use a single search key and store search records. This means searches can only be done on a single partition worth of compute at 10K RU and have a storage limit of 20 GiB. This means you have to perodically clean out storage.
+
+It also can not be written atomically, because you cannot write across partition keys in an atomic manner. This would not matter if you could scan scross partition, but as we can't...

--- a/workflow/storage/cosmosdb/cosmosdb.go
+++ b/workflow/storage/cosmosdb/cosmosdb.go
@@ -33,6 +33,8 @@ var _ storage.Vault = &Vault{}
 
 // Vault implements the storage.Vault interface.
 type Vault struct {
+	// collection is the name of the collection in the database.
+	collection string
 	// db is the CosmosDB database name for the storage.
 	db string
 	// container is the CosmosDB container name for the storage.
@@ -112,15 +114,35 @@ func WithItemOptions(opts azcosmos.ItemOptions) Option {
 	}
 }
 
-// New is the constructor for *Vault. db, container, and pval are used to identify the storage container.
+// New is the constructor for *Vault. collection is the name of the collection in the database. This is used to group
+// a set of coercion nodes together while sharing the same database and container. db is the database name that will
+// be inserted in "https://%s.documents.azure.com:443/". Container is the name of the CosmosDB container.
+// "cred is the Azure CosmosDB token credential. reg is the coercion registry.
 // If the container does not exist, it will be created.
-func New(ctx context.Context, db, container string, cred azcore.TokenCredential, reg *registry.Register, options ...Option) (*Vault, error) {
+func New(ctx context.Context, collection, db, container string, cred azcore.TokenCredential, reg *registry.Register, options ...Option) (*Vault, error) {
 	ctx = context.WithoutCancel(ctx)
 
+	if collection == "" {
+		return nil, fmt.Errorf("collection name cannot be empty")
+	}
+	if db == "" {
+		return nil, fmt.Errorf("db name cannot be empty")
+	}
+	if container == "" {
+		return nil, fmt.Errorf("container name cannot be empty")
+	}
+	if cred == nil {
+		return nil, fmt.Errorf("credential cannot be nil")
+	}
+	if reg == nil {
+		return nil, fmt.Errorf("registry cannot be nil")
+	}
+
 	r := &Vault{
-		db:        db,
-		container: container,
-		endpoint:  fmt.Sprintf("https://%s.documents.azure.com:443/", db),
+		collection: collection,
+		db:         db,
+		container:  container,
+		endpoint:   fmt.Sprintf("https://%s.documents.azure.com:443/", db),
 	}
 	for _, o := range options {
 		if err := o(r); err != nil {
@@ -145,15 +167,17 @@ func New(ctx context.Context, db, container string, cred azcore.TokenCredential,
 
 	r.reader = reader{
 		mu:           mu,
+		collection:   collection,
 		container:    container,
 		client:       r.contClient,
 		defaultIOpts: &r.itemOpts,
 		reg:          reg,
 	}
 	r.creator = creator{
-		mu:     mu,
-		client: r.contClient,
-		reader: r.reader,
+		mu:         mu,
+		collection: collection,
+		client:     r.contClient,
+		reader:     r.reader,
 	}
 	r.updater = newUpdater(mu, r.contClient, &r.itemOpts)
 	r.deleter = deleter{
@@ -286,6 +310,7 @@ func pathToScalar(path string) azcosmos.IncludedPath {
 
 // indexPaths are the included paths for the container.
 var indexPaths = []azcosmos.IncludedPath{
+	pathToScalar("collection"), // plans, checks, sequences, actions
 	pathToScalar("type"),       // plans, checks, sequences, actions
 	pathToScalar("groupID"),    // plans
 	pathToScalar("submitTime"), // plans

--- a/workflow/storage/cosmosdb/cosmosdb.go
+++ b/workflow/storage/cosmosdb/cosmosdb.go
@@ -33,8 +33,8 @@ var _ storage.Vault = &Vault{}
 
 // Vault implements the storage.Vault interface.
 type Vault struct {
-	// collection is the name of the collection in the database.
-	collection string
+	// swarm is the name of the swarm in the database.
+	swarm string
 	// db is the CosmosDB database name for the storage.
 	db string
 	// container is the CosmosDB container name for the storage.
@@ -114,16 +114,16 @@ func WithItemOptions(opts azcosmos.ItemOptions) Option {
 	}
 }
 
-// New is the constructor for *Vault. collection is the name of the collection in the database. This is used to group
+// New is the constructor for *Vault. swarm is the name of the swarm in the database. This is used to group
 // a set of coercion nodes together while sharing the same database and container. db is the database name that will
 // be inserted in "https://%s.documents.azure.com:443/". Container is the name of the CosmosDB container.
 // "cred is the Azure CosmosDB token credential. reg is the coercion registry.
 // If the container does not exist, it will be created.
-func New(ctx context.Context, collection, db, container string, cred azcore.TokenCredential, reg *registry.Register, options ...Option) (*Vault, error) {
+func New(ctx context.Context, swarm, db, container string, cred azcore.TokenCredential, reg *registry.Register, options ...Option) (*Vault, error) {
 	ctx = context.WithoutCancel(ctx)
 
-	if collection == "" {
-		return nil, fmt.Errorf("collection name cannot be empty")
+	if swarm == "" {
+		return nil, fmt.Errorf("swarm name cannot be empty")
 	}
 	if db == "" {
 		return nil, fmt.Errorf("db name cannot be empty")
@@ -139,10 +139,10 @@ func New(ctx context.Context, collection, db, container string, cred azcore.Toke
 	}
 
 	r := &Vault{
-		collection: collection,
-		db:         db,
-		container:  container,
-		endpoint:   fmt.Sprintf("https://%s.documents.azure.com:443/", db),
+		swarm:     swarm,
+		db:        db,
+		container: container,
+		endpoint:  fmt.Sprintf("https://%s.documents.azure.com:443/", db),
 	}
 	for _, o := range options {
 		if err := o(r); err != nil {
@@ -167,17 +167,17 @@ func New(ctx context.Context, collection, db, container string, cred azcore.Toke
 
 	r.reader = reader{
 		mu:           mu,
-		collection:   collection,
+		swarm:        swarm,
 		container:    container,
 		client:       r.contClient,
 		defaultIOpts: &r.itemOpts,
 		reg:          reg,
 	}
 	r.creator = creator{
-		mu:         mu,
-		collection: collection,
-		client:     r.contClient,
-		reader:     r.reader,
+		mu:     mu,
+		swarm:  swarm,
+		client: r.contClient,
+		reader: r.reader,
 	}
 	r.updater = newUpdater(mu, r.contClient, &r.itemOpts)
 	r.deleter = deleter{
@@ -310,7 +310,7 @@ func pathToScalar(path string) azcosmos.IncludedPath {
 
 // indexPaths are the included paths for the container.
 var indexPaths = []azcosmos.IncludedPath{
-	pathToScalar("collection"), // plans, checks, sequences, actions
+	pathToScalar("swarm"),      // plans, checks, sequences, actions
 	pathToScalar("type"),       // plans, checks, sequences, actions
 	pathToScalar("groupID"),    // plans
 	pathToScalar("submitTime"), // plans

--- a/workflow/storage/cosmosdb/cosmosdb.go
+++ b/workflow/storage/cosmosdb/cosmosdb.go
@@ -4,6 +4,8 @@ to implement the storage.Vault interface.
 
 This package is for use only by the coercion.Workstream and any use outside of that is not
 supported.
+
+DO NOT USE THIS PACKAGE!!!! SERIOUSLY, DO NOT USE THIS PACKAGE!!!!! See notes in the file READ_FIRST.md .
 */
 package cosmosdb
 

--- a/workflow/storage/cosmosdb/creator.go
+++ b/workflow/storage/cosmosdb/creator.go
@@ -26,9 +26,10 @@ type creatorReader interface {
 
 // creator implements the storage.creator interface.
 type creator struct {
-	mu     *sync.RWMutex
-	client creatorClient
-	reader creatorReader
+	mu         *sync.RWMutex
+	collection string
+	client     creatorClient
+	reader     creatorReader
 
 	private.Storage
 }

--- a/workflow/storage/cosmosdb/creator.go
+++ b/workflow/storage/cosmosdb/creator.go
@@ -26,10 +26,10 @@ type creatorReader interface {
 
 // creator implements the storage.creator interface.
 type creator struct {
-	mu         *sync.RWMutex
-	collection string
-	client     creatorClient
-	reader     creatorReader
+	mu     *sync.RWMutex
+	swarm  string
+	client creatorClient
+	reader creatorReader
 
 	private.Storage
 }

--- a/workflow/storage/cosmosdb/creator_plan.go
+++ b/workflow/storage/cosmosdb/creator_plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/element-of-surprise/coercion/plugins"
@@ -79,7 +80,7 @@ func batchRetryer(batch azcosmos.TransactionalBatch, client creatorClient) expon
 			return err
 		}
 		for i, result := range results.OperationResults {
-			if result.StatusCode != 201 {
+			if result.StatusCode != http.StatusCreated {
 				return fmt.Errorf("item(%d) has status code %d: %w", i, result.StatusCode, exponential.ErrPermanent)
 			}
 		}

--- a/workflow/storage/cosmosdb/fake_storage.go
+++ b/workflow/storage/cosmosdb/fake_storage.go
@@ -27,7 +27,7 @@ import (
 
 // TODO: Improve this so that we take into account the partition key so if that doesn't match it doesn't return.
 
-const collection = "collection"
+const swarm = "swarm"
 
 // fakeStorage fakes the storage methods needed to communicate with azcosmos used in this package.
 // We have to use some unsafe methods to avoid writing unneccesary wrappers to get at data used for mocks.
@@ -313,7 +313,7 @@ func (f *fakeStorage) WritePlan(ctx context.Context, plan *workflow.Plan) error 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	ictx, err := planToItems(collection, plan)
+	ictx, err := planToItems(swarm, plan)
 	if err != nil {
 		panic(err)
 	}
@@ -672,7 +672,7 @@ func (f *fakeStorage) patchPlan(ctx context.Context, itemID string, op pathOps, 
 	}
 	f.patchObject(op, item.Value.(stateObject))
 
-	ictx, err := planToItems(collection, plan)
+	ictx, err := planToItems(swarm, plan)
 	if err != nil {
 		panic(err)
 	}

--- a/workflow/storage/cosmosdb/fake_storage.go
+++ b/workflow/storage/cosmosdb/fake_storage.go
@@ -27,6 +27,8 @@ import (
 
 // TODO: Improve this so that we take into account the partition key so if that doesn't match it doesn't return.
 
+const collection = "collection"
+
 // fakeStorage fakes the storage methods needed to communicate with azcosmos used in this package.
 // We have to use some unsafe methods to avoid writing unneccesary wrappers to get at data used for mocks.
 // This is sad and cost us a lot of time.
@@ -311,7 +313,7 @@ func (f *fakeStorage) WritePlan(ctx context.Context, plan *workflow.Plan) error 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	ictx, err := planToItems(plan)
+	ictx, err := planToItems(collection, plan)
 	if err != nil {
 		panic(err)
 	}
@@ -502,7 +504,7 @@ func (f *fakeStorage) searchItemPager(query string, pk azcosmos.PartitionKey, o 
 		panic("NewQueryItemsPager: query parameters must exist")
 	}
 
-	if len(o.QueryParameters) == 0 {
+	if len(o.QueryParameters) == 1 {
 		return f.limitItemPager(query, pk, o)
 	}
 	for _, p := range o.QueryParameters {
@@ -510,7 +512,6 @@ func (f *fakeStorage) searchItemPager(query string, pk azcosmos.PartitionKey, o 
 			return f.limitItemPager(query, pk, o)
 		}
 	}
-
 	ids := map[uuid.UUID]struct{}{}
 	if o != nil && len(o.QueryParameters) > 0 {
 		ids = getIDsFromQueryParameters(o.QueryParameters)
@@ -671,7 +672,7 @@ func (f *fakeStorage) patchPlan(ctx context.Context, itemID string, op pathOps, 
 	}
 	f.patchObject(op, item.Value.(stateObject))
 
-	ictx, err := planToItems(plan)
+	ictx, err := planToItems(collection, plan)
 	if err != nil {
 		panic(err)
 	}

--- a/workflow/storage/cosmosdb/fake_storage.go
+++ b/workflow/storage/cosmosdb/fake_storage.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"reflect"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/element-of-surprise/coercion/plugins/registry"
 	"github.com/element-of-surprise/coercion/workflow"
 	"github.com/element-of-surprise/coercion/workflow/utils/walk"
+	"github.com/go-json-experiment/json"
 	"github.com/google/uuid"
 	"zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitex"
@@ -36,19 +38,36 @@ type fakeStorage struct {
 	pool *sqlitex.Pool
 	reg  *registry.Register
 
-	readItemErr   error
-	queryItemsErr bool
-	createItemErr bool
-	deleteItemErr bool
+	readItemErr    error
+	queryItemsErr  bool
+	createItemErr  bool
+	deleteItemErr  bool
+	replaceItemErr bool
 }
 
 func newFakeStorage(reg *registry.Register) *fakeStorage {
-	const table = `
+	const (
+		pagesTable = `
 CREATE Table If Not Exists pages (
 	id TEXT PRIMARY KEY,
 	plan_id TEXT NOT NULL,
 	data BLOB NOT NULL
 );`
+
+		searchTable = `
+CREATE Table If Not Exists search (
+	id TEXT PRIMARY KEY,
+	group_id TEXT,
+	name string,
+	descr string,
+	status INTEGER,
+	stateStart INTEGER,
+	stateEnd INTEGER,
+	submitTime INTEGER,
+	data BLOB NOT NULL
+);`
+	)
+
 	var flags sqlite.OpenFlags
 	flags |= sqlite.OpenReadWrite
 	flags |= sqlite.OpenCreate
@@ -79,7 +98,14 @@ CREATE Table If Not Exists pages (
 
 	if err := sqlitex.ExecuteTransient(
 		conn,
-		table,
+		pagesTable,
+		&sqlitex.ExecOptions{},
+	); err != nil {
+		panic(fmt.Sprintf("couldn't create table: %s", err))
+	}
+	if err := sqlitex.ExecuteTransient(
+		conn,
+		searchTable,
 		&sqlitex.ExecOptions{},
 	); err != nil {
 		panic(fmt.Sprintf("couldn't create table: %s", err))
@@ -102,6 +128,41 @@ func (f *fakeStorage) writeData(ctx context.Context, id, planID string, data []b
 			"$id":      id,
 			"$plan_id": planID,
 			"$data":    data,
+		},
+	})
+
+	if err != nil {
+		panic(err)
+	}
+	return nil
+}
+
+func (f *fakeStorage) writeSearchData(ctx context.Context, data []byte) (err error) {
+	const q = `INSERT OR REPLACE INTO search (id, group_id, name, descr, status, stateStart, stateEnd, submitTime, data) VALUES ($id, $group_id, $name, $descr, $status, $stateStart, $stateEnd, $submitTime, $data);`
+
+	se := searchEntry{}
+	if err := json.Unmarshal(data, &se); err != nil {
+		panic(err)
+	}
+
+	conn, err := f.pool.Take(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("couldn't get a connection from the pool: %s", err))
+	}
+	defer f.pool.Put(conn)
+	defer sqlitex.Transaction(conn)(&err)
+
+	err = sqlitex.Execute(conn, q, &sqlitex.ExecOptions{
+		Named: map[string]any{
+			"$id":         se.ID.String(),
+			"$group_id":   se.GroupID.String(),
+			"$name":       se.Name,
+			"$descr":      se.Descr,
+			"$status":     int(se.StateStatus),
+			"$stateStart": int(se.StateStart.UnixNano()),
+			"$stateEnd":   int(se.StateEnd.UnixNano()),
+			"$submitTime": int(se.SubmitTime.UnixNano()),
+			"$data":       data,
 		},
 	})
 
@@ -137,44 +198,45 @@ func (f *fakeStorage) deleteItem(ctx context.Context, id string) (err error) {
 	return nil
 }
 
-type data struct {
-	id     string
-	planID string
-	data   []byte
-}
+func (f *fakeStorage) deleteSearchEntry(ctx context.Context, id string) (err error) {
+	const q = `DELETE FROM search WHERE id = $id;`
 
-func (f *fakeStorage) allIDs(conn *sqlite.Conn) ([]data, error) {
-	const fetchAll = `SELECT id, plan_id, data FROM pages`
+	if f.deleteItemErr {
+		return errors.New("error")
+	}
 
-	d := []data{}
-	err := sqlitex.Execute(
-		conn,
-		fetchAll,
-		&sqlitex.ExecOptions{
-			ResultFunc: func(stmt *sqlite.Stmt) error {
-				b := make([]byte, stmt.GetLen("data"))
-				stmt.GetBytes("data", b)
-				d = append(
-					d,
-					data{
-						id:     stmt.GetText("id"),
-						planID: stmt.GetText("plan_id"),
-						data:   b,
-					},
-				)
-				return nil
-			},
+	conn, err := f.pool.Take(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("couldn't get a connection from the pool: %s", err))
+	}
+	defer f.pool.Put(conn)
+	defer sqlitex.Transaction(conn)(&err)
+
+	err = sqlitex.Execute(conn, q, &sqlitex.ExecOptions{
+		Named: map[string]any{
+			"$id": id,
 		},
-	)
+	})
+
 	if err != nil {
 		panic(err)
 	}
-	return d, nil
+	return nil
 }
 
-// ExecuteTransactionalBatch creates a transactional batch.
+// NewTransactionalBatch creates a transactional batch.
 func (f *fakeStorage) NewTransactionalBatch(partitionKey azcosmos.PartitionKey) azcosmos.TransactionalBatch {
-	return azcosmos.TransactionalBatch{}
+	batch := &azcosmos.TransactionalBatch{}
+	// Ensure the input is a pointer to a struct
+	batchVal := reflect.ValueOf(batch).Elem()
+
+	// Get the field
+	partitionKeyField := batchVal.FieldByName("partitionKey")
+
+	// Use unsafe to set the field directly
+	fieldPtr := unsafe.Pointer(partitionKeyField.UnsafeAddr())
+	*(*azcosmos.PartitionKey)(fieldPtr) = partitionKey
+	return *batch
 }
 
 // ExecuteTransactionalBatch implements the ExecuteBatcher interface.
@@ -182,7 +244,7 @@ func (f *fakeStorage) ExecuteTransactionalBatch(ctx context.Context, b azcosmos.
 	if reflect.ValueOf(b).IsZero() {
 		return azcosmos.TransactionalBatchResponse{}, fmt.Errorf("empty transactional batch")
 	}
-	ops := unsafeBatchOps(&b)
+	key, ops := unsafeBatchOps(&b)
 
 	for _, op := range ops {
 		switch op.op {
@@ -190,6 +252,7 @@ func (f *fakeStorage) ExecuteTransactionalBatch(ctx context.Context, b azcosmos.
 			if f.createItemErr {
 				return azcosmos.TransactionalBatchResponse{}, errors.New("error")
 			}
+
 			fields, err := getCommonFields(op.resourceBody)
 			if err != nil {
 				panic(err)
@@ -201,15 +264,41 @@ func (f *fakeStorage) ExecuteTransactionalBatch(ctx context.Context, b azcosmos.
 				id = fields.PlanID
 			}
 
-			if err := f.writeData(ctx, id.String(), fields.PlanID.String(), op.resourceBody); err != nil {
-				panic(err)
+			if key == searchKeyStr {
+				if err := f.writeSearchData(ctx, op.resourceBody); err != nil {
+					panic(err)
+				}
+			} else {
+				if err := f.writeData(ctx, id.String(), fields.PlanID.String(), op.resourceBody); err != nil {
+					panic(err)
+				}
 			}
 		case "Delete":
 			if f.deleteItemErr {
 				return azcosmos.TransactionalBatchResponse{}, errors.New("error")
 			}
-			if err := f.deleteItem(ctx, op.itemID); err != nil {
-				return azcosmos.TransactionalBatchResponse{}, err
+			if key == searchKeyStr {
+				if err := f.deleteSearchEntry(ctx, op.itemID); err != nil {
+					return azcosmos.TransactionalBatchResponse{}, err
+				}
+			} else {
+				if err := f.deleteItem(ctx, op.itemID); err != nil {
+					return azcosmos.TransactionalBatchResponse{}, err
+				}
+			}
+		case "Replace":
+			if f.replaceItemErr {
+				return azcosmos.TransactionalBatchResponse{}, errors.New("error")
+			}
+
+			if key == searchKeyStr {
+				if err := f.writeSearchData(ctx, op.resourceBody); err != nil {
+					panic(err)
+				}
+			} else {
+				if err := f.writeData(ctx, op.itemID, "", op.resourceBody); err != nil {
+					panic(err)
+				}
 			}
 		default:
 			panic("do not support the TransactionBatch op: " + op.op)
@@ -287,6 +376,9 @@ func (f *fakeStorage) readItem(ctx context.Context, itemID string) (data []byte,
 				stmt.GetBytes("data", b)
 				item = b
 				planID = stmt.GetText("plan_id")
+				if planID == "" {
+					planID = itemID
+				}
 				return nil
 			},
 		},
@@ -318,6 +410,17 @@ func (f *fakeStorage) NewQueryItemsPager(query string, pk azcosmos.PartitionKey,
 			},
 		})
 	}
+
+	s, _ := partitionKeyToStr(&pk)
+	if s == searchKeyStr {
+		return f.searchItemPager(query, pk, o)
+	}
+
+	return f.pagesItemPager(query, pk, o)
+}
+
+func (f *fakeStorage) pagesItemPager(query string, pk azcosmos.PartitionKey, o *azcosmos.QueryOptions) *runtime.Pager[azcosmos.QueryItemsResponse] {
+	const q = `SELECT id, data FROM pages`
 
 	if o.QueryParameters == nil {
 		panic("NewQueryItemsPager: query parameters must exist")
@@ -391,6 +494,110 @@ func (f *fakeStorage) NewQueryItemsPager(query string, pk azcosmos.PartitionKey,
 	})
 }
 
+func (f *fakeStorage) searchItemPager(query string, pk azcosmos.PartitionKey, o *azcosmos.QueryOptions) *runtime.Pager[azcosmos.QueryItemsResponse] {
+	const q = `SELECT id, group_id, name, descr, status, stateStart, stateEnd, submitTime, data FROM search`
+
+	// id, group_id, name, descr, status, stateStart, stateEnd, submitTime
+	if o.QueryParameters == nil {
+		panic("NewQueryItemsPager: query parameters must exist")
+	}
+
+	if len(o.QueryParameters) == 0 {
+		return f.limitItemPager(query, pk, o)
+	}
+	for _, p := range o.QueryParameters {
+		if "@limit" == p.Name {
+			return f.limitItemPager(query, pk, o)
+		}
+	}
+
+	ids := map[uuid.UUID]struct{}{}
+	if o != nil && len(o.QueryParameters) > 0 {
+		ids = getIDsFromQueryParameters(o.QueryParameters)
+	}
+
+	conn, err := f.pool.Take(context.Background())
+	if err != nil {
+		panic("can't get conn object")
+	}
+	defer f.pool.Put(conn)
+
+	items := [][]byte{}
+	err = sqlitex.Execute(
+		conn,
+		q,
+		&sqlitex.ExecOptions{
+			ResultFunc: func(stmt *sqlite.Stmt) error {
+				b := make([]byte, stmt.GetLen("data"))
+				stmt.GetBytes("data", b)
+				if _, ok := ids[uuid.MustParse(stmt.GetText("id"))]; ok {
+					items = append(items, b)
+				}
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		panic("some type of sqlite error: " + err.Error())
+	}
+
+	return runtime.NewPager(runtime.PagingHandler[azcosmos.QueryItemsResponse]{
+		More: func(page azcosmos.QueryItemsResponse) bool {
+			return page.ContinuationToken != nil
+		},
+		Fetcher: func(ctx context.Context, page *azcosmos.QueryItemsResponse) (azcosmos.QueryItemsResponse, error) {
+			return azcosmos.QueryItemsResponse{Items: items}, nil
+		},
+	})
+}
+
+func (f *fakeStorage) limitItemPager(query string, pk azcosmos.PartitionKey, o *azcosmos.QueryOptions) *runtime.Pager[azcosmos.QueryItemsResponse] {
+	const q = `SELECT data FROM search limit $limit`
+
+	var limit = math.MaxInt
+	for _, p := range o.QueryParameters {
+		if "@limit" == p.Name {
+			limit = int(p.Value.(int64))
+			break
+		}
+	}
+
+	conn, err := f.pool.Take(context.Background())
+	if err != nil {
+		panic("can't get conn object")
+	}
+	defer f.pool.Put(conn)
+
+	items := [][]byte{}
+	err = sqlitex.Execute(
+		conn,
+		q,
+		&sqlitex.ExecOptions{
+			Named: map[string]any{
+				"$limit": limit,
+			},
+			ResultFunc: func(stmt *sqlite.Stmt) error {
+				b := make([]byte, stmt.GetLen("data"))
+				stmt.GetBytes("data", b)
+				items = append(items, b)
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		panic("some type of sqlite error: " + err.Error())
+	}
+
+	return runtime.NewPager(runtime.PagingHandler[azcosmos.QueryItemsResponse]{
+		More: func(page azcosmos.QueryItemsResponse) bool {
+			return page.ContinuationToken != nil
+		},
+		Fetcher: func(ctx context.Context, page *azcosmos.QueryItemsResponse) (azcosmos.QueryItemsResponse, error) {
+			return azcosmos.QueryItemsResponse{Items: items}, nil
+		},
+	})
+}
+
 type getIDer interface {
 	GetID() uuid.UUID
 }
@@ -418,43 +625,62 @@ func (f *fakeStorage) PatchItem(ctx context.Context, key azcosmos.PartitionKey, 
 				log.Println("plan ID was: ", common.ID.String())
 			*/
 
-			reader := reader{client: f, reg: f.reg}
-
-			plan, err := reader.docToPlan(ctx, &azcosmos.ItemResponse{Value: b})
-			if err != nil {
-				panic("could not convert document to plan object: " + err.Error())
-			}
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			items := walk.Plan(ctx, plan)
-			var item walk.Item
-			for item = range items {
-				id := item.Value.(getIDer).GetID()
-				if id.String() == itemID {
-					cancel()
-					break
+			if k, _ := partitionKeyToStr(&key); k == searchKeyStr {
+				if resp, err := f.patchSearchEntry(ctx, b); err != nil {
+					return resp, err
 				}
 			}
-			if item.IsZero() {
-				return azcosmos.ItemResponse{}, fmt.Errorf("%q could not be found", itemID)
-			}
-			f.patchObject(op, item.Value.(stateObject))
-
-			ictx, err := planToItems(plan)
-			if err != nil {
-				panic(err)
-			}
-
-			for k, v := range ictx.m {
-				if err := f.writeData(context.Background(), k, plan.GetID().String(), v); err != nil {
-					panic(err)
-				}
+			if resp, err := f.patchPlan(ctx, itemID, op, po, b); err != nil {
+				return resp, err
 			}
 		default:
 			panic(fmt.Sprintf("we don't suport this operation yet: %s", op.Op))
 		}
 	}
 
+	return azcosmos.ItemResponse{}, nil
+}
+
+func (f *fakeStorage) patchSearchEntry(ctx context.Context, b []byte) (azcosmos.ItemResponse, error) {
+	if err := f.writeSearchData(ctx, b); err != nil {
+		return azcosmos.ItemResponse{}, fmt.Errorf("could not patch search entry: %s", err)
+	}
+	return azcosmos.ItemResponse{}, nil
+}
+
+func (f *fakeStorage) patchPlan(ctx context.Context, itemID string, op pathOps, po azcosmos.PatchOperations, b []byte) (azcosmos.ItemResponse, error) {
+	reader := reader{client: f, reg: f.reg}
+	plan, err := reader.docToPlan(ctx, &azcosmos.ItemResponse{Value: b})
+	if err != nil {
+		panic("could not convert document to plan object: " + err.Error())
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	items := walk.Plan(ctx, plan)
+	var item walk.Item
+	for item = range items {
+		id := item.Value.(getIDer).GetID()
+		if id.String() == itemID {
+			cancel()
+			break
+		}
+	}
+	if item.IsZero() {
+		return azcosmos.ItemResponse{}, fmt.Errorf("%q could not be found", itemID)
+	}
+	f.patchObject(op, item.Value.(stateObject))
+
+	ictx, err := planToItems(plan)
+	if err != nil {
+		panic(err)
+	}
+
+	for k, v := range ictx.m {
+		if err := f.writeData(context.Background(), k, plan.GetID().String(), v); err != nil {
+			panic(err)
+		}
+	}
 	return azcosmos.ItemResponse{}, nil
 }
 
@@ -490,6 +716,9 @@ func (f *fakeStorage) patchObject(op pathOps, o stateObject) {
 			state.Start = op.Value.(time.Time)
 		case "/stateEnd":
 			state.End = op.Value.(time.Time)
+		case "/submitTime":
+			plan := o.(*workflow.Plan)
+			plan.SubmitTime = op.Value.(time.Time)
 		default:
 			panic(fmt.Sprintf("unsupported op Path(%s) on replace op", op.Path))
 		}
@@ -568,8 +797,13 @@ type batchOp struct {
 // Rant: come on, they have an internal mock implementation they don't expose, make it difficult to locally test with
 // mock outs and love using pointers all over when they aren't necessary so my garbage collector can be full all the time.
 // Blah.........
-func unsafeBatchOps(t *azcosmos.TransactionalBatch) []batchOp {
+func unsafeBatchOps(t *azcosmos.TransactionalBatch) (string, []batchOp) {
 	poType := reflect.TypeOf(*t)
+
+	key, foundKey := getPartitionKeyValueAsString(t)
+	if !foundKey {
+		panic("Partition key not found")
+	}
 
 	// Locate the `operations` field.
 	field, found := poType.FieldByName("operations")
@@ -621,6 +855,10 @@ func unsafeBatchOps(t *azcosmos.TransactionalBatch) []batchOp {
 		case strings.Contains(name, "batchOperationCreate"):
 			field := getUnexportedField[[]byte](opValue, "resourceBody")
 			ops = append(ops, batchOp{op: "Create", resourceBody: field})
+		case strings.Contains(name, "batchOperationReplace"):
+			rsc := getUnexportedField[[]byte](opValue, "resourceBody")
+			id := getUnexportedField[string](opValue, "id")
+			ops = append(ops, batchOp{op: "Replace", itemID: id, resourceBody: rsc})
 		case strings.Contains(name, "batchOperationDelete"):
 			field := getUnexportedField[string](opValue, "id")
 			ops = append(ops, batchOp{op: "Delete", itemID: field})
@@ -628,7 +866,80 @@ func unsafeBatchOps(t *azcosmos.TransactionalBatch) []batchOp {
 			panic(fmt.Sprintf("TransactionalBatch contains an unknown operation type: %T", opValue.Interface()))
 		}
 	}
-	return ops
+	return key, ops
+}
+
+func getPartitionKeyValueAsString(batch *azcosmos.TransactionalBatch) (string, bool) {
+	// Use reflection to access the `partitionKey` field
+	batchVal := reflect.ValueOf(batch).Elem()
+	partitionKeyField := batchVal.FieldByName("partitionKey")
+
+	if !partitionKeyField.IsValid() {
+		return "", false
+	}
+
+	// Access `values` field inside `partitionKey`
+	valuesField := partitionKeyField.FieldByName("values")
+	if !valuesField.IsValid() || valuesField.Kind() != reflect.Slice {
+		return "", false
+	}
+
+	// Check if there is at least one element
+	if valuesField.Len() == 0 {
+		return "", false
+	}
+
+	// Access the first element
+	firstElem := valuesField.Index(0)
+
+	// Extract the actual value inside the interface{}
+	if firstElem.Kind() == reflect.Interface {
+		firstElem = firstElem.Elem() // Unwrap the interface
+	}
+
+	// Ensure the value is a string
+	if firstElem.Kind() != reflect.String {
+		return "", false
+	}
+
+	// Extract the string safely
+	str := firstElem.String()
+	return str, true
+}
+
+func partitionKeyToStr(k *azcosmos.PartitionKey) (string, bool) {
+	if k == nil {
+		return "", false
+	}
+
+	v := reflect.ValueOf(k).Elem()
+	valuesField := v.FieldByName("values")
+
+	if !valuesField.IsValid() || valuesField.Kind() != reflect.Slice {
+		return "", false
+	}
+
+	// Check if there is at least one element
+	if valuesField.Len() == 0 {
+		return "", false
+	}
+
+	// Access the first element
+	firstElem := valuesField.Index(0)
+
+	// Extract the actual value inside the interface{}
+	if firstElem.Kind() == reflect.Interface {
+		firstElem = firstElem.Elem() // Unwrap the interface
+	}
+
+	// Ensure the value is a string
+	if firstElem.Kind() != reflect.String {
+		return "", false
+	}
+
+	// Extract the string safely
+	str := firstElem.String()
+	return str, true
 }
 
 // getUnexportedField retrieves an unexported field using unsafe.Pointer

--- a/workflow/storage/cosmosdb/key.go
+++ b/workflow/storage/cosmosdb/key.go
@@ -2,54 +2,32 @@ package cosmosdb
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+	"github.com/element-of-surprise/coercion/workflow"
+	"github.com/google/uuid"
 )
 
 // key returns the partition key given the key value as either a uuid.UUID, *workflow.Plan, or string.
 func key(v any) azcosmos.PartitionKey {
-	return azcosmos.NewPartitionKeyString("cosmosdbIsBad")
-
-	// CosmosDB in its infinite wisdom, thinks that high availability is more important
-	// being able to actually use the database. So, it doesn't support not using partition keys.
-	// This means I have to use cosmos as a key value store, which is not what I want.
-	// Because there weren't a bunch of way better products to do key/value with...........
-	// Anyways, so until then we have to return a static key.
-	//
-	// When we enable this one day in 2030, r.client.NewQueryItemsPager() in reader.Search() will need to
-	// be updated to use the nil parition key and remove key().
-	/*
-		switch x := v.(type) {
-		case uuid.UUID:
-			return azcosmos.NewPartitionKeyString(x.String())
-		case *workflow.Plan:
-			return azcosmos.NewPartitionKeyString(x.ID.String())
-		case string:
-			return azcosmos.NewPartitionKeyString(x)
-		}
-		panic("unknown type")
-	*/
+	switch x := v.(type) {
+	case uuid.UUID:
+		return azcosmos.NewPartitionKeyString(x.String())
+	case *workflow.Plan:
+		return azcosmos.NewPartitionKeyString(x.ID.String())
+	case string:
+		return azcosmos.NewPartitionKeyString(x)
+	}
+	panic("unknown type")
 }
 
 // key returns the partition key as a string given the key value as either a uuid.UUID, *workflow.Plan, or string.
 func keyStr(v any) string {
-	return "cosmosdbIsBad"
-
-	// CosmosDB in its infinite wisdom, thinks that high availability is more important
-	// being able to actually use the database. So, it doesn't support not using partition keys.
-	// This means I have to use cosmos as a key value store, which is not what I want.
-	// Because there weren't a bunch of way better products to do key/value with...........
-	// Anyways, so until then we have to return a staic key.
-	//
-	// When we enable this one day in 2030, r.client.NewQueryItemsPager() in reader.Search() will need to
-	// be updated to use the nil partition key and remove key().
-	/*
-		switch x := v.(type) {
-		case uuid.UUID:
-			return azcosmos.NewPartitionKeyString(x.String())
-		case *workflow.Plan:
-			return azcosmos.NewPartitionKeyString(x.ID.String())
-		case string:
-			return azcosmos.NewPartitionKeyString(x)
-		}
-		panic("unknown type")
-	*/
+	switch x := v.(type) {
+	case uuid.UUID:
+		return x.String()
+	case *workflow.Plan:
+		return x.GetID().String()
+	case string:
+		return x
+	}
+	panic("unknown type")
 }

--- a/workflow/storage/cosmosdb/reader.go
+++ b/workflow/storage/cosmosdb/reader.go
@@ -97,9 +97,6 @@ const searchKeyStr = "planSearch"
 
 var searchKey = azcosmos.NewPartitionKeyString(searchKeyStr)
 
-// DOAK - This is where you are at, fix Search and List to use the searchKey and search records.
-// ALSO, you need to update key.go to use the right keys and remove "doesntmatterwhatiput" from any code.
-
 // Search returns a list of Plan IDs that match the filter.
 func (r reader) Search(ctx context.Context, filters storage.Filters) (chan storage.Stream[storage.ListResult], error) {
 	if err := filters.Validate(); err != nil {

--- a/workflow/storage/cosmosdb/reader.go
+++ b/workflow/storage/cosmosdb/reader.go
@@ -20,9 +20,9 @@ import (
 
 const (
 	// beginning of query to list plans with a filter
-	searchPlans = `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection`
+	searchPlans = `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm`
 	// list all plans without parameters
-	listPlans = `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection ORDER BY c.submitTime DESC`
+	listPlans = `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm ORDER BY c.submitTime DESC`
 )
 
 // readerClient provides abstraction for testing reader. This is implmented by *azcosmos.ContainerClient.
@@ -34,7 +34,7 @@ type readerClient interface {
 // reader implements the storage.PlanReader interface.
 type reader struct {
 	mu           *sync.RWMutex
-	collection   string
+	swarm        string
 	container    string
 	client       readerClient // *azcosmos.ContainerClient
 	defaultIOpts *azcosmos.ItemOptions
@@ -144,7 +144,7 @@ func (r reader) Search(ctx context.Context, filters storage.Filters) (chan stora
 
 func (r reader) buildSearchQuery(filters storage.Filters) (string, []azcosmos.QueryParameter) {
 	parameters := []azcosmos.QueryParameter{
-		{Name: "@collection", Value: r.collection},
+		{Name: "@swarm", Value: r.swarm},
 	}
 
 	build := strings.Builder{}
@@ -206,7 +206,7 @@ func (r reader) buildSearchQuery(filters storage.Filters) (string, []azcosmos.Qu
 // limit == 0, there is no limit.
 func (r reader) List(ctx context.Context, limit int) (chan storage.Stream[storage.ListResult], error) {
 	parameters := []azcosmos.QueryParameter{
-		{Name: "@collection", Value: r.collection},
+		{Name: "@swarm", Value: r.swarm},
 	}
 	q := listPlans
 	if limit > 0 {

--- a/workflow/storage/cosmosdb/reader_test.go
+++ b/workflow/storage/cosmosdb/reader_test.go
@@ -35,7 +35,13 @@ func TestBuildSearchQuery(t *testing.T) {
 		{
 			name:      "Success: empty filters",
 			filters:   storage.Filters{},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection ORDER BY c.submitTime DESC`,
+			wantParams: []azcosmos.QueryParameter{
+				{
+					Name:  "@collection",
+					Value: collection,
+				},
+			},
 		},
 		{
 			name: "Success: by IDs with single ID",
@@ -44,8 +50,12 @@ func TestBuildSearchQuery(t *testing.T) {
 					id1,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
+				{
+					Name:  "@collection",
+					Value: collection,
+				},
 				{
 					Name: "@ids",
 					Value: []uuid.UUID{
@@ -62,8 +72,12 @@ func TestBuildSearchQuery(t *testing.T) {
 					id2,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
+				{
+					Name:  "@collection",
+					Value: collection,
+				},
 				{
 					Name: "@ids",
 					Value: []uuid.UUID{
@@ -80,8 +94,12 @@ func TestBuildSearchQuery(t *testing.T) {
 					id1,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
+				{
+					Name:  "@collection",
+					Value: collection,
+				},
 				{
 					Name: "@group_ids",
 					Value: []uuid.UUID{
@@ -98,8 +116,12 @@ func TestBuildSearchQuery(t *testing.T) {
 					id2,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
+				{
+					Name:  "@collection",
+					Value: collection,
+				},
 				{
 					Name: "@group_ids",
 					Value: []uuid.UUID{
@@ -116,8 +138,12 @@ func TestBuildSearchQuery(t *testing.T) {
 					workflow.Completed,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.stateStatus = @status0 ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND c.stateStatus = @status0 ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
+				{
+					Name:  "@collection",
+					Value: collection,
+				},
 				{
 					Name:  "@status0",
 					Value: workflow.Completed,
@@ -132,8 +158,12 @@ func TestBuildSearchQuery(t *testing.T) {
 					workflow.Failed,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
+				{
+					Name:  "@collection",
+					Value: collection,
+				},
 				{
 					Name:  "@status0",
 					Value: workflow.Completed,
@@ -159,8 +189,12 @@ func TestBuildSearchQuery(t *testing.T) {
 					workflow.Failed,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@ids, c.id) AND ARRAY_CONTAINS(@group_ids, c.groupID) AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@ids, c.id) AND ARRAY_CONTAINS(@group_ids, c.groupID) AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
+				{
+					Name:  "@collection",
+					Value: collection,
+				},
 				{
 					Name:  "@status0",
 					Value: workflow.Completed,
@@ -187,7 +221,8 @@ func TestBuildSearchQuery(t *testing.T) {
 
 	for _, test := range tests {
 		r := reader{
-			container: "test",
+			collection: collection,
+			container:  "test",
 		}
 		query, params := r.buildSearchQuery(test.filters)
 		if test.wantQuery != query {

--- a/workflow/storage/cosmosdb/reader_test.go
+++ b/workflow/storage/cosmosdb/reader_test.go
@@ -35,11 +35,11 @@ func TestBuildSearchQuery(t *testing.T) {
 		{
 			name:      "Success: empty filters",
 			filters:   storage.Filters{},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
 				{
-					Name:  "@collection",
-					Value: collection,
+					Name:  "@swarm",
+					Value: swarm,
 				},
 			},
 		},
@@ -50,11 +50,11 @@ func TestBuildSearchQuery(t *testing.T) {
 					id1,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm AND ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
 				{
-					Name:  "@collection",
-					Value: collection,
+					Name:  "@swarm",
+					Value: swarm,
 				},
 				{
 					Name: "@ids",
@@ -72,11 +72,11 @@ func TestBuildSearchQuery(t *testing.T) {
 					id2,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm AND ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
 				{
-					Name:  "@collection",
-					Value: collection,
+					Name:  "@swarm",
+					Value: swarm,
 				},
 				{
 					Name: "@ids",
@@ -94,11 +94,11 @@ func TestBuildSearchQuery(t *testing.T) {
 					id1,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm AND ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
 				{
-					Name:  "@collection",
-					Value: collection,
+					Name:  "@swarm",
+					Value: swarm,
 				},
 				{
 					Name: "@group_ids",
@@ -116,11 +116,11 @@ func TestBuildSearchQuery(t *testing.T) {
 					id2,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm AND ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
 				{
-					Name:  "@collection",
-					Value: collection,
+					Name:  "@swarm",
+					Value: swarm,
 				},
 				{
 					Name: "@group_ids",
@@ -138,11 +138,11 @@ func TestBuildSearchQuery(t *testing.T) {
 					workflow.Completed,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND c.stateStatus = @status0 ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm AND c.stateStatus = @status0 ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
 				{
-					Name:  "@collection",
-					Value: collection,
+					Name:  "@swarm",
+					Value: swarm,
 				},
 				{
 					Name:  "@status0",
@@ -158,11 +158,11 @@ func TestBuildSearchQuery(t *testing.T) {
 					workflow.Failed,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
 				{
-					Name:  "@collection",
-					Value: collection,
+					Name:  "@swarm",
+					Value: swarm,
 				},
 				{
 					Name:  "@status0",
@@ -189,11 +189,11 @@ func TestBuildSearchQuery(t *testing.T) {
 					workflow.Failed,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.collection=@collection AND ARRAY_CONTAINS(@ids, c.id) AND ARRAY_CONTAINS(@group_ids, c.groupID) AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.swarm=@swarm AND ARRAY_CONTAINS(@ids, c.id) AND ARRAY_CONTAINS(@group_ids, c.groupID) AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
 				{
-					Name:  "@collection",
-					Value: collection,
+					Name:  "@swarm",
+					Value: swarm,
 				},
 				{
 					Name:  "@status0",
@@ -221,8 +221,8 @@ func TestBuildSearchQuery(t *testing.T) {
 
 	for _, test := range tests {
 		r := reader{
-			collection: collection,
-			container:  "test",
+			swarm:     swarm,
+			container: "test",
 		}
 		query, params := r.buildSearchQuery(test.filters)
 		if test.wantQuery != query {

--- a/workflow/storage/cosmosdb/reader_test.go
+++ b/workflow/storage/cosmosdb/reader_test.go
@@ -35,13 +35,7 @@ func TestBuildSearchQuery(t *testing.T) {
 		{
 			name:      "Success: empty filters",
 			filters:   storage.Filters{},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.type=@objectType AND ORDER BY c.submitTime DESC`,
-			wantParams: []azcosmos.QueryParameter{
-				{
-					Name:  "@objectType",
-					Value: int64(1),
-				},
-			},
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c ORDER BY c.submitTime DESC`,
 		},
 		{
 			name: "Success: by IDs with single ID",
@@ -50,12 +44,8 @@ func TestBuildSearchQuery(t *testing.T) {
 					id1,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.type=@objectType AND ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
-				{
-					Name:  "@objectType",
-					Value: int64(1),
-				},
 				{
 					Name: "@ids",
 					Value: []uuid.UUID{
@@ -72,12 +62,8 @@ func TestBuildSearchQuery(t *testing.T) {
 					id2,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.type=@objectType AND ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@ids, c.id) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
-				{
-					Name:  "@objectType",
-					Value: int64(1),
-				},
 				{
 					Name: "@ids",
 					Value: []uuid.UUID{
@@ -94,12 +80,8 @@ func TestBuildSearchQuery(t *testing.T) {
 					id1,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.type=@objectType AND ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
-				{
-					Name:  "@objectType",
-					Value: int64(1),
-				},
 				{
 					Name: "@group_ids",
 					Value: []uuid.UUID{
@@ -116,12 +98,8 @@ func TestBuildSearchQuery(t *testing.T) {
 					id2,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.type=@objectType AND ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@group_ids, c.groupID) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
-				{
-					Name:  "@objectType",
-					Value: int64(1),
-				},
 				{
 					Name: "@group_ids",
 					Value: []uuid.UUID{
@@ -138,12 +116,8 @@ func TestBuildSearchQuery(t *testing.T) {
 					workflow.Completed,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.type=@objectType AND c.stateStatus = @status0 ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.stateStatus = @status0 ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
-				{
-					Name:  "@objectType",
-					Value: int64(1),
-				},
 				{
 					Name:  "@status0",
 					Value: workflow.Completed,
@@ -158,12 +132,8 @@ func TestBuildSearchQuery(t *testing.T) {
 					workflow.Failed,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.type=@objectType AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
-				{
-					Name:  "@objectType",
-					Value: int64(1),
-				},
 				{
 					Name:  "@status0",
 					Value: workflow.Completed,
@@ -189,12 +159,8 @@ func TestBuildSearchQuery(t *testing.T) {
 					workflow.Failed,
 				},
 			},
-			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE c.type=@objectType AND ARRAY_CONTAINS(@ids, c.id) AND ARRAY_CONTAINS(@group_ids, c.groupID) AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
+			wantQuery: `SELECT c.id, c.groupID, c.name, c.descr, c.submitTime, c.stateStatus, c.stateStart, c.stateEnd FROM c WHERE ARRAY_CONTAINS(@ids, c.id) AND ARRAY_CONTAINS(@group_ids, c.groupID) AND (c.stateStatus = @status0 OR c.stateStatus = @status1) ORDER BY c.submitTime DESC`,
 			wantParams: []azcosmos.QueryParameter{
-				{
-					Name:  "@objectType",
-					Value: int64(1),
-				},
 				{
 					Name:  "@status0",
 					Value: workflow.Completed,

--- a/workflow/storage/cosmosdb/schema.go
+++ b/workflow/storage/cosmosdb/schema.go
@@ -113,3 +113,19 @@ type actionsEntry struct {
 
 	ETag azcore.ETag `json:"_etag,omitempty"`
 }
+
+// ok, to deal with the fact that we can't do multiple partition keys in the go sdk, we are going to put all an index
+// for searching into a single partition key. This will be the partition key will contain only the search index.
+// Without any compression, about 500K entries make about 109MiB. So this should hold us for a while, especially if we are
+// going to do 30/60/90 day retention.
+type searchEntry struct {
+	PartitionKey string          `json:"partitionKey"`
+	Name         string          `json:"name,omitempty"`
+	Descr        string          `json:"descr,omitempty"`
+	ID           uuid.UUID       `json:"id,omitempty"`
+	GroupID      uuid.UUID       `json:"groupID,omitempty"`
+	SubmitTime   time.Time       `json:"submitTime,omitempty"`
+	StateStatus  workflow.Status `json:"stateStatus,omitempty"`
+	StateStart   time.Time       `json:"stateStart,omitempty"`
+	StateEnd     time.Time       `json:"stateEnd,omitempty"`
+}

--- a/workflow/storage/cosmosdb/schema.go
+++ b/workflow/storage/cosmosdb/schema.go
@@ -10,7 +10,7 @@ import (
 
 type plansEntry struct {
 	PartitionKey string              `json:"partitionKey"`
-	Collection   string              `json:"collection"`
+	Swarm        string              `json:"swarm"`
 	Type         workflow.ObjectType `json:"type,omitempty"`
 	ID           uuid.UUID           `json:"id,omitempty"`
 	// PlanID is the unique identifier for the plan. This is a duplicate of ID. All other items have ID and PlanID.
@@ -38,7 +38,7 @@ type plansEntry struct {
 
 type blocksEntry struct {
 	PartitionKey      string              `json:"partitionKey"`
-	Collection        string              `json:"collection"`
+	Swarm             string              `json:"swarm"`
 	Type              workflow.ObjectType `json:"type,omitempty"`
 	ID                uuid.UUID           `json:"id,omitempty"`
 	Key               uuid.UUID           `json:"key,omitempty"`
@@ -65,7 +65,7 @@ type blocksEntry struct {
 
 type checksEntry struct {
 	PartitionKey string              `json:"partitionKey"`
-	Collection   string              `json:"collection"`
+	Swarm        string              `json:"swarm"`
 	Type         workflow.ObjectType `json:"type,omitempty"`
 	ID           uuid.UUID           `json:"id,omitempty"`
 	Key          uuid.UUID           `json:"key,omitempty"`
@@ -81,7 +81,7 @@ type checksEntry struct {
 
 type sequencesEntry struct {
 	PartitionKey string              `json:"partitionKey"`
-	Collection   string              `json:"collection"`
+	Swarm        string              `json:"swarm"`
 	Type         workflow.ObjectType `json:"type,omitempty"`
 	ID           uuid.UUID           `json:"id,omitempty"`
 	Key          uuid.UUID           `json:"key,omitempty"`
@@ -99,7 +99,7 @@ type sequencesEntry struct {
 
 type actionsEntry struct {
 	PartitionKey string              `json:"partitionKey"`
-	Collection   string              `json:"collection"`
+	Swarm        string              `json:"swarm"`
 	Type         workflow.ObjectType `json:"type,omitempty"`
 	ID           uuid.UUID           `json:"id,omitempty"`
 	Key          uuid.UUID           `json:"key,omitempty"`
@@ -125,7 +125,7 @@ type actionsEntry struct {
 // going to do 30/60/90 day retention.
 type searchEntry struct {
 	PartitionKey string          `json:"partitionKey"`
-	Collection   string          `json:"collection"`
+	Swarm        string          `json:"swarm"`
 	Name         string          `json:"name,omitempty"`
 	Descr        string          `json:"descr,omitempty"`
 	ID           uuid.UUID       `json:"id,omitempty"`

--- a/workflow/storage/cosmosdb/schema.go
+++ b/workflow/storage/cosmosdb/schema.go
@@ -10,6 +10,7 @@ import (
 
 type plansEntry struct {
 	PartitionKey string              `json:"partitionKey"`
+	Collection   string              `json:"collection"`
 	Type         workflow.ObjectType `json:"type,omitempty"`
 	ID           uuid.UUID           `json:"id,omitempty"`
 	// PlanID is the unique identifier for the plan. This is a duplicate of ID. All other items have ID and PlanID.
@@ -37,6 +38,7 @@ type plansEntry struct {
 
 type blocksEntry struct {
 	PartitionKey      string              `json:"partitionKey"`
+	Collection        string              `json:"collection"`
 	Type              workflow.ObjectType `json:"type,omitempty"`
 	ID                uuid.UUID           `json:"id,omitempty"`
 	Key               uuid.UUID           `json:"key,omitempty"`
@@ -63,6 +65,7 @@ type blocksEntry struct {
 
 type checksEntry struct {
 	PartitionKey string              `json:"partitionKey"`
+	Collection   string              `json:"collection"`
 	Type         workflow.ObjectType `json:"type,omitempty"`
 	ID           uuid.UUID           `json:"id,omitempty"`
 	Key          uuid.UUID           `json:"key,omitempty"`
@@ -78,6 +81,7 @@ type checksEntry struct {
 
 type sequencesEntry struct {
 	PartitionKey string              `json:"partitionKey"`
+	Collection   string              `json:"collection"`
 	Type         workflow.ObjectType `json:"type,omitempty"`
 	ID           uuid.UUID           `json:"id,omitempty"`
 	Key          uuid.UUID           `json:"key,omitempty"`
@@ -95,6 +99,7 @@ type sequencesEntry struct {
 
 type actionsEntry struct {
 	PartitionKey string              `json:"partitionKey"`
+	Collection   string              `json:"collection"`
 	Type         workflow.ObjectType `json:"type,omitempty"`
 	ID           uuid.UUID           `json:"id,omitempty"`
 	Key          uuid.UUID           `json:"key,omitempty"`
@@ -120,6 +125,7 @@ type actionsEntry struct {
 // going to do 30/60/90 day retention.
 type searchEntry struct {
 	PartitionKey string          `json:"partitionKey"`
+	Collection   string          `json:"collection"`
 	Name         string          `json:"name,omitempty"`
 	Descr        string          `json:"descr,omitempty"`
 	ID           uuid.UUID       `json:"id,omitempty"`

--- a/workflow/storage/cosmosdb/testing.go
+++ b/workflow/storage/cosmosdb/testing.go
@@ -178,9 +178,13 @@ func getIDsFromQueryParameters(params []azcosmos.QueryParameter) map[uuid.UUID]s
 
 type commonFields struct {
 	ID          uuid.UUID           `json:"id"`
-	PlanID      uuid.UUID           `json:"planID"` // not set on a Type plan
+	PlanID      uuid.UUID           `json:"planID"`  // not set on a Type plan
+	GroupID     uuid.UUID           `json:"groupID"` // not set except on Type plan
+	Name        string              `json:"name"`
+	Descr       string              `json:"descr"`
 	Type        workflow.ObjectType `json:"type"`
 	StateStatus workflow.Status     `json:"stateStatus"`
+	SubmitTime  time.Time           `json:"submitTime"` // not set except on Type plan
 	StateStart  time.Time           `json:"stateStart"`
 	StateEnd    time.Time           `json:"stateEnd"`
 }

--- a/workflow/storage/cosmosdb/testing/integration/cli
+++ b/workflow/storage/cosmosdb/testing/integration/cli
@@ -1,1 +1,1 @@
- go run main.go -collection-name="whatever" -db-name="medbaydb" -container-name="doak"
+ go run main.go -swarm-name="whatever" -db-name="medbaydb" -container-name="doak"

--- a/workflow/storage/cosmosdb/testing/integration/cli
+++ b/workflow/storage/cosmosdb/testing/integration/cli
@@ -1,1 +1,1 @@
- go run main.go -db-name="medbaydb" -container-name="doak"
+ go run main.go -collection-name="whatever" -db-name="medbaydb" -container-name="doak"

--- a/workflow/storage/cosmosdb/testing/integration/cli
+++ b/workflow/storage/cosmosdb/testing/integration/cli
@@ -1,0 +1,1 @@
+ go run main.go -db-name="medbaydb" -container-name="doak"

--- a/workflow/storage/cosmosdb/testing/integration/main.go
+++ b/workflow/storage/cosmosdb/testing/integration/main.go
@@ -23,11 +23,11 @@ import (
 //+gocover:ignore:file No need to test fake store.
 
 var (
-	db         = flag.String("db-name", os.Getenv("AZURE_COSMOSDB_DBNAME"), "the name of the cosmosdb database")
-	collection = flag.String("collection-name", os.Getenv("AZURE_COSMOSDB_COLLECTION"), "the name of the cosmosdb collection")
-	container  = flag.String("container-name", os.Getenv("AZURE_COSMOSDB_CNAME"), "the name of the cosmosdb container")
-	msi        = flag.String("msi", "", "the identity with vmss contributor role. If empty, az login is used")
-	teardown   = flag.Bool("teardown", false, "teardown the cosmosdb container")
+	db        = flag.String("db-name", os.Getenv("AZURE_COSMOSDB_DBNAME"), "the name of the cosmosdb database")
+	swarm     = flag.String("swarm-name", os.Getenv("AZURE_COSMOSDB_SWARM"), "the name of the coercion swarm")
+	container = flag.String("container-name", os.Getenv("AZURE_COSMOSDB_CNAME"), "the name of the cosmosdb container")
+	msi       = flag.String("msi", "", "the identity with vmss contributor role. If empty, az login is used")
+	teardown  = flag.Bool("teardown", false, "teardown the cosmosdb container")
 )
 
 var zeroTime = time.Unix(0, 0)
@@ -68,7 +68,7 @@ func main() {
 		fatalErr(logger, "Failed to create credential: %v", err)
 	}
 
-	vault, err := cosmosdb.New(ctx, *collection, *db, *container, cred, reg)
+	vault, err := cosmosdb.New(ctx, *swarm, *db, *container, cred, reg)
 	if err != nil {
 		fatalErr(logger, "Failed to create vault: %v", err)
 	}

--- a/workflow/storage/cosmosdb/testing/integration/main.go
+++ b/workflow/storage/cosmosdb/testing/integration/main.go
@@ -23,10 +23,11 @@ import (
 //+gocover:ignore:file No need to test fake store.
 
 var (
-	db        = flag.String("db-name", os.Getenv("AZURE_COSMOSDB_DBNAME"), "the name of the cosmosdb database")
-	container = flag.String("container-name", os.Getenv("AZURE_COSMOSDB_CNAME"), "the name of the cosmosdb container")
-	msi       = flag.String("msi", "", "the identity with vmss contributor role. If empty, az login is used")
-	teardown  = flag.Bool("teardown", false, "teardown the cosmosdb container")
+	db         = flag.String("db-name", os.Getenv("AZURE_COSMOSDB_DBNAME"), "the name of the cosmosdb database")
+	collection = flag.String("collection-name", os.Getenv("AZURE_COSMOSDB_COLLECTION"), "the name of the cosmosdb collection")
+	container  = flag.String("container-name", os.Getenv("AZURE_COSMOSDB_CNAME"), "the name of the cosmosdb container")
+	msi        = flag.String("msi", "", "the identity with vmss contributor role. If empty, az login is used")
+	teardown   = flag.Bool("teardown", false, "teardown the cosmosdb container")
 )
 
 var zeroTime = time.Unix(0, 0)
@@ -67,7 +68,7 @@ func main() {
 		fatalErr(logger, "Failed to create credential: %v", err)
 	}
 
-	vault, err := cosmosdb.New(ctx, *db, *container, cred, reg)
+	vault, err := cosmosdb.New(ctx, *collection, *db, *container, cred, reg)
 	if err != nil {
 		fatalErr(logger, "Failed to create vault: %v", err)
 	}

--- a/workflow/storage/cosmosdb/updater.go
+++ b/workflow/storage/cosmosdb/updater.go
@@ -118,7 +118,7 @@ func replaceSearch(ctx context.Context, client creatorClient, plan *workflow.Pla
 
 	b, err := json.Marshal(plan)
 	if err != nil {
-		return azcosmos.TransactionalBatchResponse{}, fmt.Errorf("failed to marshal search recordd: %w", err)
+		return azcosmos.TransactionalBatchResponse{}, fmt.Errorf("failed to marshal search record: %w", err)
 	}
 
 	se := searchEntry{

--- a/workflow/storage/cosmosdb/updater_actions.go
+++ b/workflow/storage/cosmosdb/updater_actions.go
@@ -16,8 +16,7 @@ var _ storage.ActionUpdater = actionUpdater{}
 
 // actionUpdater implements the storage.actionUpdater interface.
 type actionUpdater struct {
-	mu *sync.RWMutex
-
+	mu     *sync.RWMutex
 	client patchItemer
 
 	defaultIOpts *azcosmos.ItemOptions


### PR DESCRIPTION
This changes the code from a single partition to multiple partitions.

All objects belonging to a plan are now partitioned by the PlanID to which they belong.
There is now a searchEntry that is placed under a key called "planSearch".  Objects in this partition are used to search or list plans.

Queries and fakes have been updated for these changes.  

Tests and integration tests all pass. 