### PR TITLE
Adding cosmosdb recovery to fix up search after a service crash

### DIFF
--- a/coercion.go
+++ b/coercion.go
@@ -54,6 +54,13 @@ func New(ctx context.Context, reg *registry.Register, store storage.Vault, optio
 		return nil, fmt.Errorf("registry is required")
 	}
 
+	// Some storage systems may need to recover from a previous state after a crash.
+	if r, ok := store.(storage.Recovery); ok {
+		if err := r.Recovery(ctx); err != nil {
+			return nil, fmt.Errorf("failed to recover storage: %w", err)
+		}
+	}
+
 	ws := &Workstream{reg: reg, store: store}
 	for _, o := range options {
 		if err := o(ws); err != nil {

--- a/workflow/storage/cosmosdb/cosmosdb.go
+++ b/workflow/storage/cosmosdb/cosmosdb.go
@@ -57,6 +57,7 @@ type Vault struct {
 	updater
 	closer
 	deleter
+	recovery
 
 	private.Storage
 }
@@ -186,6 +187,7 @@ func New(ctx context.Context, swarm, db, container string, cred azcore.TokenCred
 		reader: r.reader,
 	}
 	r.closer = closer{}
+	r.recovery = recovery{reader: r.reader, updater: r.updater}
 	return r, nil
 }
 

--- a/workflow/storage/cosmosdb/reader.go
+++ b/workflow/storage/cosmosdb/reader.go
@@ -31,7 +31,7 @@ type readerClient interface {
 	NewQueryItemsPager(query string, partitionKey azcosmos.PartitionKey, o *azcosmos.QueryOptions) *runtime.Pager[azcosmos.QueryItemsResponse]
 }
 
-// reader implements the storage.PlanReader interface.
+// reader implements the storage.Reader interface.
 type reader struct {
 	mu           *sync.RWMutex
 	swarm        string

--- a/workflow/storage/cosmosdb/recovery.go
+++ b/workflow/storage/cosmosdb/recovery.go
@@ -1,0 +1,37 @@
+package cosmosdb
+
+import (
+	"fmt"
+
+	"github.com/element-of-surprise/coercion/workflow"
+	"github.com/element-of-surprise/coercion/workflow/storage"
+	"github.com/gostdlib/base/context"
+)
+
+type recovery struct {
+	reader  storage.Reader
+	updater storage.Updater
+}
+
+// Recovery implements storage.Recovery. There is a case where when we write our search entries
+// an update could be missed because writing the object and the search entry is not atomic.
+// The service could die between these operations. This method is used to recover from that case.
+func (r recovery) Recovery(ctx context.Context) error {
+	stream, err := r.reader.Search(ctx, storage.Filters{ByStatus: []workflow.Status{workflow.Running}})
+	if err != nil {
+		return err
+	}
+	for entry := range stream {
+		if entry.Err != nil {
+			return entry.Err
+		}
+		p, err := r.reader.Read(ctx, entry.Result.ID)
+		if err != nil {
+			return fmt.Errorf("failed to locate entry %v that is in the search stream", entry.Result.ID)
+		}
+		if err := r.updater.UpdatePlan(ctx, p); err != nil {
+			return fmt.Errorf("failed to update plan %v", p.ID)
+		}
+	}
+	return nil
+}

--- a/workflow/storage/cosmosdb/recovery_test.go
+++ b/workflow/storage/cosmosdb/recovery_test.go
@@ -1,0 +1,136 @@
+package cosmosdb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/element-of-surprise/coercion/workflow"
+	"github.com/element-of-surprise/coercion/workflow/storage"
+	"github.com/google/uuid"
+	"github.com/kylelemons/godebug/pretty"
+)
+
+var pConfig = &pretty.Config{
+	PrintStringers: true,
+}
+
+type fakeSearch struct {
+	results                       []storage.ListResult
+	readResult                    *workflow.Plan
+	searchErr, readErr, updateErr bool
+
+	storage.Reader
+}
+
+func (f *fakeSearch) Read(ctx context.Context, id uuid.UUID) (*workflow.Plan, error) {
+	if f.readErr {
+		return nil, errors.New("error")
+	}
+	return f.readResult, nil
+}
+
+func (f *fakeSearch) Search(ctx context.Context, filters storage.Filters) (chan storage.Stream[storage.ListResult], error) {
+	if f.searchErr {
+		return nil, errors.New("error")
+	}
+
+	ch := make(chan storage.Stream[storage.ListResult], 1)
+	go func() {
+		defer close(ch)
+		for _, result := range f.results {
+			ch <- storage.Stream[storage.ListResult]{Result: result}
+		}
+	}()
+
+	return ch, nil
+}
+
+type fakeUpdatePlan struct {
+	err       bool
+	updateWas *workflow.Plan
+	storage.Updater
+}
+
+func (f *fakeUpdatePlan) UpdatePlan(ctx context.Context, plan *workflow.Plan) error {
+	if f.err {
+		return errors.New("error")
+	}
+	f.updateWas = plan
+	return nil
+}
+
+func TestRecovery(t *testing.T) {
+	t.Parallel()
+
+	searchResult := []storage.ListResult{{ID: uuid.New()}}
+	readResult := &workflow.Plan{ID: searchResult[0].ID}
+
+	tests := []struct {
+		name                          string
+		results                       []storage.ListResult
+		readResult                    *workflow.Plan
+		searchErr, readErr, updateErr bool
+		err                           bool
+	}{
+		{
+			name: "No results",
+		},
+		{
+			name:      "Error: search",
+			searchErr: true,
+			err:       true,
+		},
+		{
+			name:    "Error: read plan",
+			results: searchResult,
+			readErr: true,
+			err:     true,
+		},
+		{
+			name:       "Error: update plan",
+			results:    searchResult,
+			readResult: readResult,
+			updateErr:  true,
+			err:        true,
+		},
+		{
+			name:       "Success",
+			results:    searchResult,
+			readResult: readResult,
+		},
+	}
+
+	for _, test := range tests {
+		r := recovery{
+			reader: &fakeSearch{
+				results:    test.results,
+				readResult: test.readResult,
+				searchErr:  test.searchErr,
+				readErr:    test.readErr,
+			},
+			updater: &fakeUpdatePlan{err: test.updateErr},
+		}
+		ctx := context.Background()
+
+		err := r.Recovery(ctx)
+		switch {
+		case test.err && err == nil:
+			t.Errorf("TestRecovery(%s): got err == nil, want err != nil", test.name)
+			continue
+		case !test.err && err != nil:
+			t.Errorf("TestRecovery(%s): got err == %v, want err == nil", test.name, err)
+			continue
+		case err != nil:
+			continue
+		}
+		// No results were found.
+		if r.updater.(*fakeUpdatePlan).updateWas == nil {
+			continue
+		}
+
+		if diff := pConfig.Compare(r.updater.(*fakeUpdatePlan).updateWas, readResult); diff != "" {
+			t.Errorf("TestRecovery(%s): -want/+got:\n%s", test.name, diff)
+		}
+	}
+}

--- a/workflow/storage/storage.go
+++ b/workflow/storage/storage.go
@@ -157,3 +157,9 @@ type ActionUpdater interface {
 
 	private.Storage
 }
+
+// Recovery is a Vault that must do some recovery operation before it can be used after a failure
+// or restart. Not all Vaults implement this.
+type Recovery interface {
+	Recovery(context.Context) error
+}


### PR DESCRIPTION
This adds a new storage interface, Recovery.  If a storage system implements this, it will be called on service startup.  This reconciles all running search records (any other hasn't begun or is in a completed state) by re-writing the state.  

This will happen before service recovery runs, which is going to be the next update.