### PR TITLE
pablotrivino/fixFormatForTimeDuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/brunoga/deep v1.2.4
 	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v5 v5.14.0
-	github.com/go-json-experiment/json v0.0.0-20250211222650-7564cc53b040
+	github.com/go-json-experiment/json v0.0.0-20250709061156-d2cd4771eb1b
 	github.com/gofiber/fiber/v2 v2.52.6
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v61 v61.0.0

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/go-git/go-git/v5 v5.14.0 h1:/MD3lCrGjCen5WfEAzKg00MJJffKhC8gzS80ycmCi
 github.com/go-git/go-git/v5 v5.14.0/go.mod h1:Z5Xhoia5PcWA3NF8vRLURn9E5FRhSl7dGj9ItW3Wk5k=
 github.com/go-json-experiment/json v0.0.0-20250211222650-7564cc53b040 h1:trEF1NteT0pHrGrW6AK9RBanU9VMQDnT3Xi0oQU2Jso=
 github.com/go-json-experiment/json v0.0.0-20250211222650-7564cc53b040/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
+github.com/go-json-experiment/json v0.0.0-20250709061156-d2cd4771eb1b h1:LzDYmjwGnnbVLXEuoe/Lw7hwbEXvi1A3BcUNkTxuCGU=
+github.com/go-json-experiment/json v0.0.0-20250709061156-d2cd4771eb1b/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/workflow/storage/cosmosdb/schema.go
+++ b/workflow/storage/cosmosdb/schema.go
@@ -46,8 +46,8 @@ type blocksEntry struct {
 	Name              string              `json:"name,omitempty"`
 	Descr             string              `json:"descr,omitempty"`
 	Pos               int                 `json:"pos,omitempty"`
-	EntranceDelay     time.Duration       `json:"entranceDelay,omitempty" format:"iso8601"`
-	ExitDelay         time.Duration       `json:"exitDelay,omitempty" format:"iso8601"`
+	EntranceDelay     time.Duration       `json:"entranceDelay,omitempty,format:iso8601"`
+	ExitDelay         time.Duration       `json:"exitDelay,omitempty,format:iso8601"`
 	BypassChecks      uuid.UUID           `json:"bypassChecks,omitempty"`
 	PreChecks         uuid.UUID           `json:"preChecks,omitempty"`
 	PostChecks        uuid.UUID           `json:"postChecks,omitempty"`
@@ -71,7 +71,7 @@ type checksEntry struct {
 	Key          uuid.UUID           `json:"key,omitempty"`
 	PlanID       uuid.UUID           `json:"planID,omitempty"`
 	Actions      []uuid.UUID         `json:"actions,omitempty"`
-	Delay        time.Duration       `json:"delay,omitempty" format:"iso8601"`
+	Delay        time.Duration       `json:"delay,omitempty,format:iso8601"`
 	StateStatus  workflow.Status     `json:"stateStatus,omitempty"`
 	StateStart   time.Time           `json:"stateStart,omitempty"`
 	StateEnd     time.Time           `json:"stateEnd,omitempty"`
@@ -108,7 +108,7 @@ type actionsEntry struct {
 	Descr        string              `json:"descr,omitempty"`
 	Pos          int                 `json:"pos,omitempty"`
 	Plugin       string              `json:"plugin,omitempty"`
-	Timeout      time.Duration       `json:"timeout,omitempty" format:"iso8601"`
+	Timeout      time.Duration       `json:"timeout,omitempty,format:iso8601"`
 	Retries      int                 `json:"retries,omitempty"`
 	Req          []byte              `json:"req,omitempty"`
 	Attempts     []byte              `json:"attempts,omitempty"`


### PR DESCRIPTION
In schema.go, fix the the json tag format for fields of type time.Duration. I had made a fix for this before, but did not format the tag correctly. Also update the go.mod