### PR TITLE
Fixes deadlock with group code

### DIFF
--- a/workflow/storage/azblob/azblob.go
+++ b/workflow/storage/azblob/azblob.go
@@ -21,6 +21,7 @@ package azblob
 import (
 	"fmt"
 	"strings"
+	"testing"
 	"time"
 	"unsafe"
 
@@ -187,6 +188,9 @@ func (v *Vault) ReadDirect(ctx context.Context, id uuid.UUID) (*workflow.Plan, e
 // This simulates a failed creation where the entry was written but the object was not.
 // This is intended for testing purposes only.
 func (v *Vault) CreateOrphanedEntry(ctx context.Context, p *workflow.Plan) error {
+	if !testing.Testing() {
+		panic("CreateOrphanedEntry can only be used in testing")
+	}
 	if p == nil {
 		return errors.E(ctx, errors.CatInternal, errors.TypeParameter, fmt.Errorf("plan cannot be nil"))
 	}
@@ -217,6 +221,10 @@ func (v *Vault) CreateOrphanedEntry(ctx context.Context, p *workflow.Plan) error
 // blobType should be "entry" or "object" for plan blobs.
 // This is intended for testing purposes only.
 func (v *Vault) BlobExists(ctx context.Context, planID uuid.UUID, blobType string) (bool, error) {
+	if !testing.Testing() {
+		panic("CreateOrphanedEntry can only be used in testing")
+	}
+
 	containerName := containerForPlan(v.prefix, planID)
 	var blobName string
 	switch blobType {

--- a/workflow/storage/azblob/key_test.go
+++ b/workflow/storage/azblob/key_test.go
@@ -541,17 +541,17 @@ func TestRecoveryContainerNames(t *testing.T) {
 
 			switch {
 			case err == nil && test.wantErr:
-				t.Errorf("[TestRecoveryContainerNames](%s): got err == nil, want err != nil", test.name)
+				t.Errorf("TestRecoveryContainerNames(%s): got err == nil, want err != nil", test.name)
 				return
 			case err != nil && !test.wantErr:
-				t.Errorf("[TestRecoveryContainerNames](%s): got err == %s, want err == nil", test.name, err)
+				t.Errorf("TestRecoveryContainerNames(%s): got err == %s, want err == nil", test.name, err)
 				return
 			case err != nil:
 				return
 			}
 
 			if diff := pretty.Compare(test.wantContainers, got); diff != "" {
-				t.Errorf("[TestRecoveryContainerNames](%s): -want +got:\n%s", test.name, diff)
+				t.Errorf("TestRecoveryContainerNames(%s): -want +got:\n%s", test.name, diff)
 			}
 		})
 	}

--- a/workflow/storage/azblob/reader_list_search_test.go
+++ b/workflow/storage/azblob/reader_list_search_test.go
@@ -307,21 +307,21 @@ func TestSearchWithRetentionPeriod(t *testing.T) {
 
 			resultCh, err := r.Search(ctx, test.filters)
 			if err != nil {
-				t.Errorf("[TestSearchWithRetentionPeriod](%s): got err == %v, want err == nil", test.name, err)
+				t.Errorf("TestSearchWithRetentionPeriod(%s): got err == %v, want err == nil", test.name, err)
 				return
 			}
 
 			var results []storage.ListResult
 			for res := range resultCh {
 				if res.Err != nil {
-					t.Errorf("[TestSearchWithRetentionPeriod](%s): got result err == %v", test.name, res.Err)
+					t.Errorf("TestSearchWithRetentionPeriod(%s): got result err == %v", test.name, res.Err)
 					continue
 				}
 				results = append(results, res.Result)
 			}
 
 			if len(results) != test.wantPlanCount {
-				t.Errorf("[TestSearchWithRetentionPeriod](%s): got %d results, want %d", test.name, len(results), test.wantPlanCount)
+				t.Errorf("TestSearchWithRetentionPeriod(%s): got %d results, want %d", test.name, len(results), test.wantPlanCount)
 			}
 		})
 	}
@@ -404,21 +404,21 @@ func TestSearchRecoveryScenario(t *testing.T) {
 
 			resultCh, err := r.Search(ctx, storage.Filters{ByStatus: []workflow.Status{workflow.Running}})
 			if err != nil {
-				t.Errorf("[TestSearchRecoveryScenario](%s): got err == %v, want err == nil", test.name, err)
+				t.Errorf("TestSearchRecoveryScenario(%s): got err == %v, want err == nil", test.name, err)
 				return
 			}
 
 			var results []storage.ListResult
 			for res := range resultCh {
 				if res.Err != nil {
-					t.Errorf("[TestSearchRecoveryScenario](%s): got result err == %v", test.name, res.Err)
+					t.Errorf("TestSearchRecoveryScenario(%s): got result err == %v", test.name, res.Err)
 					continue
 				}
 				results = append(results, res.Result)
 			}
 
 			if len(results) != test.wantRecoveredCount {
-				t.Errorf("[TestSearchRecoveryScenario](%s): got %d recovered plans, want %d. %s", test.name, len(results), test.wantRecoveredCount, test.description)
+				t.Errorf("TestSearchRecoveryScenario(%s): got %d recovered plans, want %d. %s", test.name, len(results), test.wantRecoveredCount, test.description)
 			}
 		})
 	}
@@ -530,21 +530,21 @@ func TestListWithRetentionPeriod(t *testing.T) {
 
 			resultCh, err := r.List(ctx, test.limit)
 			if err != nil {
-				t.Errorf("[TestListWithRetentionPeriod](%s): got err == %v, want err == nil", test.name, err)
+				t.Errorf("TestListWithRetentionPeriod(%s): got err == %v, want err == nil", test.name, err)
 				return
 			}
 
 			var results []storage.ListResult
 			for res := range resultCh {
 				if res.Err != nil {
-					t.Errorf("[TestListWithRetentionPeriod](%s): got result err == %v", test.name, res.Err)
+					t.Errorf("TestListWithRetentionPeriod(%s): got result err == %v", test.name, res.Err)
 					continue
 				}
 				results = append(results, res.Result)
 			}
 
 			if len(results) != test.wantPlanCount {
-				t.Errorf("[TestListWithRetentionPeriod](%s): got %d results, want %d", test.name, len(results), test.wantPlanCount)
+				t.Errorf("TestListWithRetentionPeriod(%s): got %d results, want %d", test.name, len(results), test.wantPlanCount)
 			}
 		})
 	}

--- a/workflow/storage/azblob/uploader_test.go
+++ b/workflow/storage/azblob/uploader_test.go
@@ -1,6 +1,7 @@
 package azblob
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -23,10 +24,12 @@ func setupUploaderTest(t *testing.T) (*blobops.Fake, *uploader) {
 
 	// Create uploader
 	u := &uploader{
-		mu:     planlocks.New(ctx),
-		client: fakeClient,
-		prefix: prefix,
-		pool:   context.Pool(ctx).Limited(ctx, "", 10),
+		mu:          planlocks.New(ctx),
+		client:      fakeClient,
+		prefix:      prefix,
+		planObjPool: context.Pool(ctx).Limited(ctx, "", 5),
+		blockPool:   context.Pool(ctx).Limited(ctx, "", 5),
+		leafObjPool: context.Pool(ctx).Limited(ctx, "", 20),
 	}
 
 	return fakeClient, u
@@ -177,10 +180,10 @@ func TestUploadPlan(t *testing.T) {
 
 			switch {
 			case err == nil && test.wantErr:
-				t.Errorf("[TestUploadPlan](%s): got err == nil, want err != nil", test.name)
+				t.Errorf("TestUploadPlan(%s): got err == nil, want err != nil", test.name)
 				return
 			case err != nil && !test.wantErr:
-				t.Errorf("[TestUploadPlan](%s): got err == %s, want err == nil", test.name, err)
+				t.Errorf("TestUploadPlan(%s): got err == %s, want err == nil", test.name, err)
 				return
 			case err != nil:
 				return
@@ -191,25 +194,25 @@ func TestUploadPlan(t *testing.T) {
 
 			// Verify plan entry blob
 			if !fakeClient.BlobExists(containerName, planEntryBlobName(test.plan.ID)) {
-				t.Errorf("[TestUploadPlan](%s): plan entry blob should exist", test.name)
+				t.Errorf("TestUploadPlan(%s): plan entry blob should exist", test.name)
 			}
 
 			// Verify plan object blob
 			if !fakeClient.BlobExists(containerName, planObjectBlobName(test.plan.ID)) {
-				t.Errorf("[TestUploadPlan](%s): plan object blob should exist", test.name)
+				t.Errorf("TestUploadPlan(%s): plan object blob should exist", test.name)
 			}
 
 			// For uptCreate, verify sub-objects were uploaded
 			if test.uploadPlanType == uptCreate {
 				if test.plan.PreChecks != nil {
 					if !fakeClient.BlobExists(containerName, checksBlobName(test.plan.ID, test.plan.PreChecks.ID)) {
-						t.Errorf("[TestUploadPlan](%s): PreChecks blob should exist for uptCreate", test.name)
+						t.Errorf("TestUploadPlan(%s): PreChecks blob should exist for uptCreate", test.name)
 					}
 				}
 
 				for _, block := range test.plan.Blocks {
 					if !fakeClient.BlobExists(containerName, blockBlobName(test.plan.ID, block.ID)) {
-						t.Errorf("[TestUploadPlan](%s): block blob should exist for uptCreate", test.name)
+						t.Errorf("TestUploadPlan(%s): block blob should exist for uptCreate", test.name)
 					}
 				}
 			}
@@ -240,22 +243,22 @@ func TestUploadPlanEntry(t *testing.T) {
 
 			// Create container first
 			if err := fakeClient.CreateContainer(ctx, containerName); err != nil {
-				t.Fatalf("[TestUploadPlanEntry]: failed to create container: %v", err)
+				t.Fatalf("TestUploadPlanEntry: failed to create container: %v", err)
 			}
 
 			md, err := planToMetadata(ctx, plan)
 			if err != nil {
-				t.Fatalf("[TestUploadPlanEntry]: failed to create metadata: %v", err)
+				t.Fatalf("TestUploadPlanEntry: failed to create metadata: %v", err)
 			}
 
 			err = u.uploadPlanEntry(ctx, plan, md)
 
 			switch {
 			case err == nil && test.wantErr:
-				t.Errorf("[TestUploadPlanEntry](%s): got err == nil, want err != nil", test.name)
+				t.Errorf("TestUploadPlanEntry(%s): got err == nil, want err != nil", test.name)
 				return
 			case err != nil && !test.wantErr:
-				t.Errorf("[TestUploadPlanEntry](%s): got err == %s, want err == nil", test.name, err)
+				t.Errorf("TestUploadPlanEntry(%s): got err == %s, want err == nil", test.name, err)
 				return
 			case err != nil:
 				return
@@ -263,22 +266,22 @@ func TestUploadPlanEntry(t *testing.T) {
 
 			// Verify blob exists
 			if !fakeClient.BlobExists(containerName, planEntryBlobName(plan.ID)) {
-				t.Errorf("[TestUploadPlanEntry](%s): plan entry blob should exist", test.name)
+				t.Errorf("TestUploadPlanEntry(%s): plan entry blob should exist", test.name)
 			}
 
 			// Verify blob content
 			data, err := fakeClient.GetBlob(ctx, containerName, planEntryBlobName(plan.ID))
 			if err != nil {
-				t.Errorf("[TestUploadPlanEntry](%s): failed to get blob: %v", test.name, err)
+				t.Errorf("TestUploadPlanEntry(%s): failed to get blob: %v", test.name, err)
 			}
 
 			var entry planEntry
 			if err := json.Unmarshal(data, &entry); err != nil {
-				t.Errorf("[TestUploadPlanEntry](%s): failed to unmarshal entry: %v", test.name, err)
+				t.Errorf("TestUploadPlanEntry(%s): failed to unmarshal entry: %v", test.name, err)
 			}
 
 			if entry.ID != plan.ID {
-				t.Errorf("[TestUploadPlanEntry](%s): entry ID mismatch: got %v, want %v", test.name, entry.ID, plan.ID)
+				t.Errorf("TestUploadPlanEntry(%s): entry ID mismatch: got %v, want %v", test.name, entry.ID, plan.ID)
 			}
 		})
 	}
@@ -307,22 +310,22 @@ func TestUploadPlanObject(t *testing.T) {
 
 			// Create container first
 			if err := fakeClient.CreateContainer(ctx, containerName); err != nil {
-				t.Fatalf("[TestUploadPlanObject]: failed to create container: %v", err)
+				t.Fatalf("TestUploadPlanObject: failed to create container: %v", err)
 			}
 
 			md, err := planToMetadata(ctx, plan)
 			if err != nil {
-				t.Fatalf("[TestUploadPlanObject]: failed to create metadata: %v", err)
+				t.Fatalf("TestUploadPlanObject: failed to create metadata: %v", err)
 			}
 
 			err = u.uploadPlanObject(ctx, plan, md)
 
 			switch {
 			case err == nil && test.wantErr:
-				t.Errorf("[TestUploadPlanObject](%s): got err == nil, want err != nil", test.name)
+				t.Errorf("TestUploadPlanObject(%s): got err == nil, want err != nil", test.name)
 				return
 			case err != nil && !test.wantErr:
-				t.Errorf("[TestUploadPlanObject](%s): got err == %s, want err == nil", test.name, err)
+				t.Errorf("TestUploadPlanObject(%s): got err == %s, want err == nil", test.name, err)
 				return
 			case err != nil:
 				return
@@ -330,22 +333,22 @@ func TestUploadPlanObject(t *testing.T) {
 
 			// Verify blob exists
 			if !fakeClient.BlobExists(containerName, planObjectBlobName(plan.ID)) {
-				t.Errorf("[TestUploadPlanObject](%s): plan object blob should exist", test.name)
+				t.Errorf("TestUploadPlanObject(%s): plan object blob should exist", test.name)
 			}
 
 			// Verify blob content
 			data, err := fakeClient.GetBlob(ctx, containerName, planObjectBlobName(plan.ID))
 			if err != nil {
-				t.Errorf("[TestUploadPlanObject](%s): failed to get blob: %v", test.name, err)
+				t.Errorf("TestUploadPlanObject(%s): failed to get blob: %v", test.name, err)
 			}
 
 			var retrievedPlan workflow.Plan
 			if err := json.Unmarshal(data, &retrievedPlan); err != nil {
-				t.Errorf("[TestUploadPlanObject](%s): failed to unmarshal plan: %v", test.name, err)
+				t.Errorf("TestUploadPlanObject(%s): failed to unmarshal plan: %v", test.name, err)
 			}
 
 			if retrievedPlan.ID != plan.ID {
-				t.Errorf("[TestUploadPlanObject](%s): plan ID mismatch: got %v, want %v", test.name, retrievedPlan.ID, plan.ID)
+				t.Errorf("TestUploadPlanObject(%s): plan ID mismatch: got %v, want %v", test.name, retrievedPlan.ID, plan.ID)
 			}
 		})
 	}
@@ -381,17 +384,17 @@ func TestUploadSubObjects(t *testing.T) {
 
 			// Create container first
 			if err := fakeClient.CreateContainer(ctx, containerName); err != nil {
-				t.Fatalf("[TestUploadSubObjects]: failed to create container: %v", err)
+				t.Fatalf("TestUploadSubObjects: failed to create container: %v", err)
 			}
 
 			err := u.uploadSubObjects(ctx, containerName, plan)
 
 			switch {
 			case err == nil && test.wantErr:
-				t.Errorf("[TestUploadSubObjects](%s): got err == nil, want err != nil", test.name)
+				t.Errorf("TestUploadSubObjects(%s): got err == nil, want err != nil", test.name)
 				return
 			case err != nil && !test.wantErr:
-				t.Errorf("[TestUploadSubObjects](%s): got err == %s, want err == nil", test.name, err)
+				t.Errorf("TestUploadSubObjects(%s): got err == %s, want err == nil", test.name, err)
 				return
 			case err != nil:
 				return
@@ -400,12 +403,12 @@ func TestUploadSubObjects(t *testing.T) {
 			// Verify checks blobs
 			if plan.PreChecks != nil {
 				if !fakeClient.BlobExists(containerName, checksBlobName(plan.ID, plan.PreChecks.ID)) {
-					t.Errorf("[TestUploadSubObjects](%s): PreChecks blob should exist", test.name)
+					t.Errorf("TestUploadSubObjects(%s): PreChecks blob should exist", test.name)
 				}
 
 				for _, action := range plan.PreChecks.Actions {
 					if !fakeClient.BlobExists(containerName, actionBlobName(plan.ID, action.ID)) {
-						t.Errorf("[TestUploadSubObjects](%s): PreChecks action blob should exist", test.name)
+						t.Errorf("TestUploadSubObjects(%s): PreChecks action blob should exist", test.name)
 					}
 				}
 			}
@@ -413,26 +416,26 @@ func TestUploadSubObjects(t *testing.T) {
 			// Verify block blobs
 			for _, block := range plan.Blocks {
 				if !fakeClient.BlobExists(containerName, blockBlobName(plan.ID, block.ID)) {
-					t.Errorf("[TestUploadSubObjects](%s): block blob should exist", test.name)
+					t.Errorf("TestUploadSubObjects(%s): block blob should exist", test.name)
 				}
 
 				// Verify block's checks
 				if block.PreChecks != nil {
 					if !fakeClient.BlobExists(containerName, checksBlobName(plan.ID, block.PreChecks.ID)) {
-						t.Errorf("[TestUploadSubObjects](%s): block PreChecks blob should exist", test.name)
+						t.Errorf("TestUploadSubObjects(%s): block PreChecks blob should exist", test.name)
 					}
 				}
 
 				// Verify sequences
 				for _, seq := range block.Sequences {
 					if !fakeClient.BlobExists(containerName, sequenceBlobName(plan.ID, seq.ID)) {
-						t.Errorf("[TestUploadSubObjects](%s): sequence blob should exist", test.name)
+						t.Errorf("TestUploadSubObjects(%s): sequence blob should exist", test.name)
 					}
 
 					// Verify actions
 					for _, action := range seq.Actions {
 						if !fakeClient.BlobExists(containerName, actionBlobName(plan.ID, action.ID)) {
-							t.Errorf("[TestUploadSubObjects](%s): sequence action blob should exist", test.name)
+							t.Errorf("TestUploadSubObjects(%s): sequence action blob should exist", test.name)
 						}
 					}
 				}
@@ -465,17 +468,17 @@ func TestUploadBlockBlob(t *testing.T) {
 
 			// Create container first
 			if err := fakeClient.CreateContainer(ctx, containerName); err != nil {
-				t.Fatalf("[TestUploadBlockBlob]: failed to create container: %v", err)
+				t.Fatalf("TestUploadBlockBlob: failed to create container: %v", err)
 			}
 
 			err := u.uploadBlockBlob(ctx, containerName, plan.ID, block, 0)
 
 			switch {
 			case err == nil && test.wantErr:
-				t.Errorf("[TestUploadBlockBlob](%s): got err == nil, want err != nil", test.name)
+				t.Errorf("TestUploadBlockBlob(%s): got err == nil, want err != nil", test.name)
 				return
 			case err != nil && !test.wantErr:
-				t.Errorf("[TestUploadBlockBlob](%s): got err == %s, want err == nil", test.name, err)
+				t.Errorf("TestUploadBlockBlob(%s): got err == %s, want err == nil", test.name, err)
 				return
 			case err != nil:
 				return
@@ -483,20 +486,20 @@ func TestUploadBlockBlob(t *testing.T) {
 
 			// Verify block blob
 			if !fakeClient.BlobExists(containerName, blockBlobName(plan.ID, block.ID)) {
-				t.Errorf("[TestUploadBlockBlob](%s): block blob should exist", test.name)
+				t.Errorf("TestUploadBlockBlob(%s): block blob should exist", test.name)
 			}
 
 			// Verify sequences
 			for _, seq := range block.Sequences {
 				if !fakeClient.BlobExists(containerName, sequenceBlobName(plan.ID, seq.ID)) {
-					t.Errorf("[TestUploadBlockBlob](%s): sequence blob should exist", test.name)
+					t.Errorf("TestUploadBlockBlob(%s): sequence blob should exist", test.name)
 				}
 			}
 
 			// Verify checks
 			if block.PreChecks != nil {
 				if !fakeClient.BlobExists(containerName, checksBlobName(plan.ID, block.PreChecks.ID)) {
-					t.Errorf("[TestUploadBlockBlob](%s): block checks blob should exist", test.name)
+					t.Errorf("TestUploadBlockBlob(%s): block checks blob should exist", test.name)
 				}
 			}
 		})
@@ -527,17 +530,17 @@ func TestUploadSequenceBlob(t *testing.T) {
 
 			// Create container first
 			if err := fakeClient.CreateContainer(ctx, containerName); err != nil {
-				t.Fatalf("[TestUploadSequenceBlob]: failed to create container: %v", err)
+				t.Fatalf("TestUploadSequenceBlob: failed to create container: %v", err)
 			}
 
 			err := u.uploadSequenceBlob(ctx, containerName, plan.ID, seq, 0)
 
 			switch {
 			case err == nil && test.wantErr:
-				t.Errorf("[TestUploadSequenceBlob](%s): got err == nil, want err != nil", test.name)
+				t.Errorf("TestUploadSequenceBlob(%s): got err == nil, want err != nil", test.name)
 				return
 			case err != nil && !test.wantErr:
-				t.Errorf("[TestUploadSequenceBlob](%s): got err == %s, want err == nil", test.name, err)
+				t.Errorf("TestUploadSequenceBlob(%s): got err == %s, want err == nil", test.name, err)
 				return
 			case err != nil:
 				return
@@ -545,13 +548,13 @@ func TestUploadSequenceBlob(t *testing.T) {
 
 			// Verify sequence blob
 			if !fakeClient.BlobExists(containerName, sequenceBlobName(plan.ID, seq.ID)) {
-				t.Errorf("[TestUploadSequenceBlob](%s): sequence blob should exist", test.name)
+				t.Errorf("TestUploadSequenceBlob(%s): sequence blob should exist", test.name)
 			}
 
 			// Verify actions
 			for _, action := range seq.Actions {
 				if !fakeClient.BlobExists(containerName, actionBlobName(plan.ID, action.ID)) {
-					t.Errorf("[TestUploadSequenceBlob](%s): action blob should exist", test.name)
+					t.Errorf("TestUploadSequenceBlob(%s): action blob should exist", test.name)
 				}
 			}
 		})
@@ -582,17 +585,17 @@ func TestUploadChecksBlob(t *testing.T) {
 
 			// Create container first
 			if err := fakeClient.CreateContainer(ctx, containerName); err != nil {
-				t.Fatalf("[TestUploadChecksBlob]: failed to create container: %v", err)
+				t.Fatalf("TestUploadChecksBlob: failed to create container: %v", err)
 			}
 
 			err := u.uploadChecksBlob(ctx, containerName, plan.ID, checks)
 
 			switch {
 			case err == nil && test.wantErr:
-				t.Errorf("[TestUploadChecksBlob](%s): got err == nil, want err != nil", test.name)
+				t.Errorf("TestUploadChecksBlob(%s): got err == nil, want err != nil", test.name)
 				return
 			case err != nil && !test.wantErr:
-				t.Errorf("[TestUploadChecksBlob](%s): got err == %s, want err == nil", test.name, err)
+				t.Errorf("TestUploadChecksBlob(%s): got err == %s, want err == nil", test.name, err)
 				return
 			case err != nil:
 				return
@@ -600,13 +603,13 @@ func TestUploadChecksBlob(t *testing.T) {
 
 			// Verify checks blob
 			if !fakeClient.BlobExists(containerName, checksBlobName(plan.ID, checks.ID)) {
-				t.Errorf("[TestUploadChecksBlob](%s): checks blob should exist", test.name)
+				t.Errorf("TestUploadChecksBlob(%s): checks blob should exist", test.name)
 			}
 
 			// Verify actions
 			for _, action := range checks.Actions {
 				if !fakeClient.BlobExists(containerName, actionBlobName(plan.ID, action.ID)) {
-					t.Errorf("[TestUploadChecksBlob](%s): action blob should exist", test.name)
+					t.Errorf("TestUploadChecksBlob(%s): action blob should exist", test.name)
 				}
 			}
 		})
@@ -637,17 +640,17 @@ func TestUploadActionBlob(t *testing.T) {
 
 			// Create container first
 			if err := fakeClient.CreateContainer(ctx, containerName); err != nil {
-				t.Fatalf("[TestUploadActionBlob]: failed to create container: %v", err)
+				t.Fatalf("TestUploadActionBlob: failed to create container: %v", err)
 			}
 
 			err := u.uploadActionBlob(ctx, containerName, plan.ID, action, 0)
 
 			switch {
 			case err == nil && test.wantErr:
-				t.Errorf("[TestUploadActionBlob](%s): got err == nil, want err != nil", test.name)
+				t.Errorf("TestUploadActionBlob(%s): got err == nil, want err != nil", test.name)
 				return
 			case err != nil && !test.wantErr:
-				t.Errorf("[TestUploadActionBlob](%s): got err == %s, want err == nil", test.name, err)
+				t.Errorf("TestUploadActionBlob(%s): got err == %s, want err == nil", test.name, err)
 				return
 			case err != nil:
 				return
@@ -655,23 +658,209 @@ func TestUploadActionBlob(t *testing.T) {
 
 			// Verify action blob
 			if !fakeClient.BlobExists(containerName, actionBlobName(plan.ID, action.ID)) {
-				t.Errorf("[TestUploadActionBlob](%s): action blob should exist", test.name)
+				t.Errorf("TestUploadActionBlob(%s): action blob should exist", test.name)
 			}
 
 			// Verify blob content
 			data, err := fakeClient.GetBlob(ctx, containerName, actionBlobName(plan.ID, action.ID))
 			if err != nil {
-				t.Errorf("[TestUploadActionBlob](%s): failed to get blob: %v", test.name, err)
+				t.Errorf("TestUploadActionBlob(%s): failed to get blob: %v", test.name, err)
 			}
 
 			var entry actionsEntry
 			if err := json.Unmarshal(data, &entry); err != nil {
-				t.Errorf("[TestUploadActionBlob](%s): failed to unmarshal action: %v", test.name, err)
+				t.Errorf("TestUploadActionBlob(%s): failed to unmarshal action: %v", test.name, err)
 			}
 
 			if entry.ID != action.ID {
-				t.Errorf("[TestUploadActionBlob](%s): action ID mismatch: got %v, want %v", test.name, entry.ID, action.ID)
+				t.Errorf("TestUploadActionBlob(%s): action ID mismatch: got %v, want %v", test.name, entry.ID, action.ID)
 			}
 		})
+	}
+}
+
+// createComplexPlan creates a plan with multiple blocks, sequences, checks, and actions
+// to maximize the potential for worker pool exhaustion in nested parallel uploads.
+func createComplexPlan(numBlocks, numSequencesPerBlock, numActionsPerSequence int) *workflow.Plan {
+	planID := workflow.NewV7()
+
+	var preCheckActions []*workflow.Action
+	for i := 0; i < 3; i++ {
+		action := &workflow.Action{
+			ID:      workflow.NewV7(),
+			Name:    "plan-pre-check-action",
+			Descr:   "plan pre-check action desc",
+			Plugin:  testPlugins.HelloPluginName,
+			Timeout: 30 * time.Second,
+			Req:     testPlugins.HelloReq{Say: "hello"},
+		}
+		action.SetState(workflow.State{Status: workflow.NotStarted})
+		preCheckActions = append(preCheckActions, action)
+	}
+
+	preChecks := &workflow.Checks{
+		ID:      workflow.NewV7(),
+		Actions: preCheckActions,
+	}
+	preChecks.SetState(workflow.State{Status: workflow.NotStarted})
+
+	var blocks []*workflow.Block
+	for b := 0; b < numBlocks; b++ {
+		// Block-level checks
+		var blockCheckActions []*workflow.Action
+		for i := 0; i < 2; i++ {
+			action := &workflow.Action{
+				ID:      workflow.NewV7(),
+				Name:    "block-check-action",
+				Descr:   "block check action desc",
+				Plugin:  testPlugins.HelloPluginName,
+				Timeout: 30 * time.Second,
+				Req:     testPlugins.HelloReq{Say: "block check"},
+			}
+			action.SetState(workflow.State{Status: workflow.NotStarted})
+			blockCheckActions = append(blockCheckActions, action)
+		}
+
+		blockPreChecks := &workflow.Checks{
+			ID:      workflow.NewV7(),
+			Actions: blockCheckActions,
+		}
+		blockPreChecks.SetState(workflow.State{Status: workflow.NotStarted})
+
+		var sequences []*workflow.Sequence
+		for s := 0; s < numSequencesPerBlock; s++ {
+			var seqActions []*workflow.Action
+			for a := 0; a < numActionsPerSequence; a++ {
+				action := &workflow.Action{
+					ID:      workflow.NewV7(),
+					Name:    "sequence-action",
+					Descr:   "sequence action desc",
+					Plugin:  testPlugins.HelloPluginName,
+					Timeout: 30 * time.Second,
+					Req:     testPlugins.HelloReq{Say: "sequence"},
+				}
+				action.SetState(workflow.State{Status: workflow.NotStarted})
+				seqActions = append(seqActions, action)
+			}
+
+			seq := &workflow.Sequence{
+				ID:      workflow.NewV7(),
+				Name:    "Test Sequence",
+				Descr:   "Test Sequence Description",
+				Actions: seqActions,
+			}
+			seq.SetState(workflow.State{Status: workflow.NotStarted})
+			sequences = append(sequences, seq)
+		}
+
+		block := &workflow.Block{
+			ID:        workflow.NewV7(),
+			Name:      "Test Block",
+			Descr:     "Test Block Description",
+			PreChecks: blockPreChecks,
+			Sequences: sequences,
+		}
+		block.SetState(workflow.State{Status: workflow.NotStarted})
+		blocks = append(blocks, block)
+	}
+
+	plan := &workflow.Plan{
+		ID:         planID,
+		Name:       "Complex Test Plan",
+		Descr:      "Complex Test Plan Description",
+		SubmitTime: time.Now().UTC(),
+		PreChecks:  preChecks,
+		Blocks:     blocks,
+	}
+	plan.SetState(workflow.State{Status: workflow.NotStarted})
+
+	return plan
+}
+
+// TestRegressionConcurrentUploadsDeadlock validates that concurrent uploads with nested parallelism
+// do not deadlock due to worker pool exhaustion. This test uses GOMAXPROCS=1 and small pool
+// sizes to maximize the likelihood of triggering the deadlock if the fix is not in place.
+//
+// The original bug occurred when multiple concurrent requests each submitted upload tasks to a single shared pool,
+// with parent tasks (uploadBlockBlob, uploadSequenceBlob) occupied workers while waiting for children.  Child tasks
+// couldn't execute because all workers were occupied by waiting parents and a deadlock occurred. Parents wait for
+// children that can never run.
+func TestRegressionConcurrentUploadsDeadlock(t *testing.T) {
+	// Set GOMAXPROCS to 1 to increase likelihood of deadlock with single-threaded scheduling
+	oldProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	ctx := context.Background()
+	fakeClient := blobops.NewFake()
+
+	// Use very small pool sizes to maximize deadlock potential
+	// With a single pool of size 2, uploading a complex plan with nested parallelism
+	// would deadlock because parent tasks would occupy both workers waiting for children.
+	// With separate pools for each level tasks at different levels
+	// should not block each other.
+	u := &uploader{
+		mu:          planlocks.New(ctx),
+		client:      fakeClient,
+		prefix:      "test",
+		planObjPool: context.Pool(ctx).Limited(ctx, "testTop", 2),
+		blockPool:   context.Pool(ctx).Limited(ctx, "testSub", 2),
+		leafObjPool: context.Pool(ctx).Limited(ctx, "testLeaf", 2),
+	}
+
+	numConcurrentUploads := 5
+	plans := make([]*workflow.Plan, numConcurrentUploads)
+	for i := 0; i < numConcurrentUploads; i++ {
+		plans[i] = createComplexPlan(3, 2, 2)
+	}
+
+	for _, plan := range plans {
+		containerName := containerForPlan("test", plan.ID)
+		if err := fakeClient.EnsureContainer(ctx, containerName); err != nil {
+			t.Fatalf("TestRegressionConcurrentUploadsDeadlock: failed to create container: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	g := context.Pool(ctx).Group()
+	for _, plan := range plans {
+		plan := plan // capture loop variable
+		g.Go(ctx, func(ctx context.Context) error {
+			containerName := containerForPlan("test", plan.ID)
+			return u.uploadSubObjects(ctx, containerName, plan)
+		})
+	}
+
+	err := g.Wait(ctx)
+
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatal("TestRegressionConcurrentUploadsDeadlock: test timed out - likely deadlock due to worker pool exhaustion")
+	}
+
+	if err != nil {
+		t.Fatalf("TestRegressionConcurrentUploadsDeadlock: unexpected error: %v", err)
+	}
+
+	for _, plan := range plans {
+		containerName := containerForPlan("test", plan.ID)
+
+		if plan.PreChecks != nil {
+			if !fakeClient.BlobExists(containerName, checksBlobName(plan.ID, plan.PreChecks.ID)) {
+				t.Errorf("TestRegressionConcurrentUploadsDeadlock: PreChecks blob should exist for plan %s", plan.ID)
+			}
+		}
+
+		for _, block := range plan.Blocks {
+			if !fakeClient.BlobExists(containerName, blockBlobName(plan.ID, block.ID)) {
+				t.Errorf("TestRegressionConcurrentUploadsDeadlock: block blob should exist for plan %s", plan.ID)
+			}
+
+			for _, seq := range block.Sequences {
+				if !fakeClient.BlobExists(containerName, sequenceBlobName(plan.ID, seq.ID)) {
+					t.Errorf("TestRegressionConcurrentUploadsDeadlock: sequence blob should exist for plan %s", plan.ID)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
So we were using a limited pool group with size 20 when doing azblob uploads. So, when maxprocs was lower, this was taking each one longer to do.  Because sub-object uploads were sharing with their parent uploads, we have cascading dependencies.  This led to deadlocks.

We now separate into 3 pools to avoid that and wrote a regression test that proved this issue.  That regession test now passes.

In addition, we were not cleaning up upload failures well.  We now do that.