### PR TITLE
handle pointer in interface field in secure package

### DIFF
--- a/workflow/utils/secrets/secure/secure.go
+++ b/workflow/utils/secrets/secure/secure.go
@@ -166,7 +166,6 @@ func walkStruct(val reflect.Value, wasPtr bool, path string, handler fieldHandle
 		}
 	}
 
-	// Return value or pointer based on what was passed in
 	if wasPtr {
 		return val.Addr().Interface(), nil
 	}
@@ -205,7 +204,6 @@ func walkSlice(val reflect.Value, wasPtr bool, path string, handler fieldHandler
 		}
 		processedVal := reflect.ValueOf(processed)
 
-		// walkValue preserves pointer-ness, so we can set directly
 		newSlice.Index(i).Set(processedVal)
 	}
 
@@ -251,7 +249,6 @@ func walkMap(val reflect.Value, wasPtr bool, path string, handler fieldHandler) 
 		}
 		processedVal := reflect.ValueOf(processed)
 
-		// walkValue preserves pointer-ness, so we can set directly
 		newMap.SetMapIndex(key, processedVal)
 	}
 

--- a/workflow/utils/secrets/secure/secure_test.go
+++ b/workflow/utils/secrets/secure/secure_test.go
@@ -66,18 +66,28 @@ type tagsStruct struct {
 	FieldC string `coerce:" "`
 }
 
-type InterfaceWrapper struct {
-	Interface
+type AnimalWrapper struct {
+	Animal	
 }
 
-type Interface interface {
+type Animal interface {
 	MakeNoise() string
 }
 
-type Lion struct {}
+type Dog struct{
+	thoughts string
+}
 
-func (*Lion) MakeNoise() string {
-	return "roar"
+func (*Dog) MakeNoise() string {
+	return "woof"
+}
+
+type Cat struct{
+	thoughts string  `coerce:"secure"`
+}
+
+func (*Cat) MakeNoise() string {
+	return "meow"
 }
 
 func TestGetTags(t *testing.T) {
@@ -137,9 +147,14 @@ func TestWalkValue(t *testing.T) {
 			want:  User{Username: "john", Password: ""},
 		},
 		{
-			name:  "Success: interface field with pointer",
-			input: InterfaceWrapper{Interface: &Lion{}},
-			want:  InterfaceWrapper{Interface: &Lion{}},
+			name:  "Success: interface field with pointer and no tag remains unchanged",
+			input: AnimalWrapper{Animal: &Dog{thoughts: "pet me"}},
+			want:  AnimalWrapper{Animal: &Dog{thoughts: "pet me"}},
+		},
+		{
+			name:  "Success: interface field with pointer and secret thoughts",
+			input: AnimalWrapper{Animal: &Cat{thoughts: "I secretly despise you, human"}},
+			want:  AnimalWrapper{Animal: &Cat{thoughts: ""}},
 		},
 		{
 			name:  "Success: struct without secure tag remains unchanged",

--- a/workflow/utils/secrets/secure/secure_test.go
+++ b/workflow/utils/secrets/secure/secure_test.go
@@ -66,6 +66,20 @@ type tagsStruct struct {
 	FieldC string `coerce:" "`
 }
 
+type InterfaceWrapper struct {
+	Interface
+}
+
+type Interface interface {
+	MakeNoise() string
+}
+
+type Lion struct {}
+
+func (*Lion) MakeNoise() string {
+	return "roar"
+}
+
 func TestGetTags(t *testing.T) {
 	t.Parallel()
 
@@ -121,6 +135,11 @@ func TestWalkValue(t *testing.T) {
 			name:  "Success: struct with secure tag has field zeroed",
 			input: User{Username: "john", Password: "secret123"},
 			want:  User{Username: "john", Password: ""},
+		},
+		{
+			name:  "Success: interface field with pointer",
+			input: InterfaceWrapper{Interface: &Lion{}},
+			want:  InterfaceWrapper{Interface: &Lion{}},
 		},
 		{
 			name:  "Success: struct without secure tag remains unchanged",

--- a/workflow/utils/secrets/secure/secure_test.go
+++ b/workflow/utils/secrets/secure/secure_test.go
@@ -67,23 +67,23 @@ type tagsStruct struct {
 }
 
 type AnimalWrapper struct {
-	Animal	
+	Animal
 }
 
 type Animal interface {
 	MakeNoise() string
 }
 
-type Dog struct{
-	thoughts string
+type Dog struct {
+	Thoughts string
 }
 
 func (*Dog) MakeNoise() string {
 	return "woof"
 }
 
-type Cat struct{
-	thoughts string  `coerce:"secure"`
+type Cat struct {
+	Thoughts string `coerce:"secure"`
 }
 
 func (*Cat) MakeNoise() string {
@@ -148,13 +148,13 @@ func TestWalkValue(t *testing.T) {
 		},
 		{
 			name:  "Success: interface field with pointer and no tag remains unchanged",
-			input: AnimalWrapper{Animal: &Dog{thoughts: "pet me"}},
-			want:  AnimalWrapper{Animal: &Dog{thoughts: "pet me"}},
+			input: AnimalWrapper{Animal: &Dog{Thoughts: "pet me"}},
+			want:  AnimalWrapper{Animal: &Dog{Thoughts: "pet me"}},
 		},
 		{
 			name:  "Success: interface field with pointer and secret thoughts",
-			input: AnimalWrapper{Animal: &Cat{thoughts: "I secretly despise you, human"}},
-			want:  AnimalWrapper{Animal: &Cat{thoughts: ""}},
+			input: AnimalWrapper{Animal: &Cat{Thoughts: "I secretly despise you, human"}},
+			want:  AnimalWrapper{Animal: &Cat{Thoughts: ""}},
 		},
 		{
 			name:  "Success: struct without secure tag remains unchanged",


### PR DESCRIPTION
I was getting a panic because the object was getting dereferenced (for e.g. v1.ServiceAccount instead of *v1.ServiceAccount, which does not implement a runtime.Object)

the code to get the test to pass is generated so I need to take a closer look still